### PR TITLE
[role/kraken.readiness/tasks/do-wait] removed --schema-cache-dir

### DIFF
--- a/ansible/roles/kraken.readiness/tasks/do-wait.yaml
+++ b/ansible/roles/kraken.readiness/tasks/do-wait.yaml
@@ -21,7 +21,7 @@
 
 - name: Wait for all nodes to join cluster (any status)
   shell: >
-    {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} get nodes --no-headers=true --v 7 --schema-cache-dir=""
+    {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} get nodes --no-headers=true --v 7
   register: job_get_nodes_result
   until: job_get_nodes_result.stdout_lines | length >= needed_nodes | int
   retries: "{{ (( readiness_wait | int ) / retry_interval | int ) | int }}"
@@ -31,7 +31,7 @@
 
 - name: Wait for all nodes to join cluster (status Ready)
   shell: >
-    {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} get nodes --no-headers=true --v 7 --schema-cache-dir="" | grep -v NotReady
+    {{ kubectl }} --kubeconfig={{ kubeconfig | expanduser }} get nodes --no-headers=true --v 7 | grep -v NotReady
   register: job_get_nodes_result
   until: job_get_nodes_result.stdout_lines | length >= needed_nodes | int
   retries: "{{ (( readiness_wait | int ) / retry_interval | int ) | int }}"


### PR DESCRIPTION
kubectl for version 1.6.4 does not understand the flag --schema-cache-dir, removing to continue support of 1.6