### PR TITLE
[Feature Request] kraken kubectl suppress ansible output by default.

### DIFF
--- a/bin/computed_kubectl.sh
+++ b/bin/computed_kubectl.sh
@@ -8,12 +8,19 @@ set -o nounset
 set -o pipefail
 
 my_dir=$(dirname "${BASH_SOURCE}")
+
 VERSIONFILE=$(mktemp /tmp/computed_kubectl.XXXXXX)
 rm ${VERSIONFILE}
+
 trap '{ rm -f -- "${VERSIONFILE}"; }' INT TERM HUP EXIT
 # Call separate script to hide our args from lib/common.sh
-${my_dir}/max_k8s_version.sh ${VERSIONFILE} -c $1
+if [[ -z ${2+x} ]]; then
+    ${my_dir}/max_k8s_version.sh ${VERSIONFILE} --config $1
+else
+    ${my_dir}/max_k8s_version.sh ${VERSIONFILE} --config $1 --verbose $2
+fi
 shift
+
 K8S_VERSION=$(cat ${VERSIONFILE} | cut -d . -f 1-2)
 rm ${VERSIONFILE}
 /opt/cnct/kubernetes/${K8S_VERSION}/bin/kubectl $@

--- a/bin/max_k8s_version.sh
+++ b/bin/max_k8s_version.sh
@@ -23,7 +23,18 @@ source "${my_dir}/../lib/common.sh"
 trap control_c SIGINT
 LOCAL_KEV="kraken_action=max_k8s_version version_outfile=${OUTFILE}"
 
-ansible-playbook ${K2_VERBOSE} -i ansible/inventory/localhost \
-	ansible/max_k8s_version.yaml --extra-vars \
-	"${KRAKEN_EXTRA_VARS}${LOCAL_KEV}" \
-    || echo "max_version failed"
+function runcmd(){
+    ansible-playbook ${K2_VERBOSE} \
+        -i ansible/inventory/localhost \
+        ansible/max_k8s_version.yaml \
+        --extra-vars "${KRAKEN_EXTRA_VARS}${LOCAL_KEV}" \
+        || echo "max_version failed" > out
+}
+
+if [[ ! -z $K2_VERBOSE ]]; then
+    runcmd
+else
+    out=`runcmd`
+fi
+
+


### PR DESCRIPTION
changed output of computed_kubectl to suppress ansible output, optionally allows you to turn it on via verbosity flag. 