### PR TITLE
trim down roles being run for update

### DIFF
--- a/ansible/roles/kraken.post/tasks/main.yaml
+++ b/ansible/roles/kraken.post/tasks/main.yaml
@@ -4,4 +4,4 @@
     - "{{ kraken_config.clusters }}"
   loop_control:
     loop_var: a_cluster
-  when: (kraken_action == 'up' or kraken_action == 'update') and not ( dryrun | bool )
+  when: (kraken_action == 'up') and not ( dryrun | bool )

--- a/ansible/update.yaml
+++ b/ansible/update.yaml
@@ -1,10 +1,32 @@
 ---
-
-- include: up.yaml
-
 - hosts: localhost
 
   roles:
     - {
+        role: 'kraken.config',
+        tags: [ 'always', 'config_only' ]
+      }
+    - {
+        role: 'roles/kraken.cluster_common',
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun' ]
+      }
+    - {
+        role: 'roles/kraken.nodePool/kraken.nodePool.selector',
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun' ]
+      }
+    - {
+        role: 'roles/kraken.assembler',
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun' ]
+      }
+    - {
+        role: 'roles/kraken.provider/kraken.provider.selector',
+        tags: [ 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun']
+      }
+    - {
         role: '{{ playbook_dir }}/roles/kraken.update/kraken.update.selector',
       }
+    - { 
+        role: 'roles/kraken.ssh/kraken.ssh.selector',
+        tags: [ 'ssh', 'all', 'dryrun' ,'ssh_only' ]
+      }
+ 

--- a/ansible/update.yaml
+++ b/ansible/update.yaml
@@ -29,4 +29,3 @@
         role: 'roles/kraken.ssh/kraken.ssh.selector',
         tags: [ 'ssh', 'all', 'dryrun' ,'ssh_only' ]
       }
- 

--- a/ansible/update.yaml
+++ b/ansible/update.yaml
@@ -25,7 +25,7 @@
     - {
         role: '{{ playbook_dir }}/roles/kraken.update/kraken.update.selector',
       }
-    - { 
+    - {
         role: 'roles/kraken.ssh/kraken.ssh.selector',
         tags: [ 'ssh', 'all', 'dryrun' ,'ssh_only' ]
       }


### PR DESCRIPTION
we have been running all roles weather needed or not on update to
ensure we don't miss anything.  since the update process was added
we have cleaned up the interfaces between roles significantly and
can now split out exactly which roles are necessary for making
changes to a running kraken-managed kubernetes cluster