### PR TITLE
update default gke version to 1.7.5

### DIFF
--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -123,7 +123,7 @@ definitions:
     - &defaultKube
       name: defaultKube
       kind: kubernetes
-      version: v1.6.9
+      version: v1.7.5
       hyperkubeLocation: gcr.io/google_containers/hyperkube
   containerConfigs:
     - &defaultDocker


### PR DESCRIPTION
changed this week, CI runs are taking 45 minutes again.