### PR TITLE
Produce valid yaml for the group key

### DIFF
--- a/ansible/roles/kraken.cluster_common/templates/locksmith.part.jinja2
+++ b/ansible/roles/kraken.cluster_common/templates/locksmith.part.jinja2
@@ -1,9 +1,9 @@
 {% if item.osConfig.locksmith is defined %}
 {% set locksmith = item.osConfig.locksmith %}
 {% if locksmith.group is defined %}
-group = {{ locksmith.group }}
+group: {{ locksmith.group }}
 {% else %}
-group = item.name
+group: {{ item.name }}
 {% endif %}
 {% if locksmith.setMax is defined %}
 set_max: {{ locksmith.setMax }}


### PR DESCRIPTION
Alter the template to produce valid yaml for the group key, and to use
the nodePool name if a locksmith group is not defined instead of
the string, "item.name".

Fixes #841