### PR TITLE
remove the 'ignore errors' for running the taints task in gke

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/main.yaml
@@ -37,5 +37,4 @@
     - nodePools
   loop_control:
     loop_var: cluster_node_tuple
-  when: kraken_action == 'up' and (cluster_node_tuple.1.nodeConfig.taints is defined or cluster_node_tuple.1.schedulingConfig.taints is defined)
-  ignore_errors: yes
+  when: kraken_action == 'up' and (cluster_node_tuple.1.nodeConfig.taints is defined or (cluster_node_tuple.1.schedulingConfig is defined and cluster_node_tuple.1.schedulingConfig.taints is defined))


### PR DESCRIPTION
ansible's boolean evaluation is 'short circuit-able' so we can test
for the parent object being defined and parsing will stop before
checking for the child.  this will prevent error messages that get
ignored and make the system slightly safer