### PR TITLE
add a readiness wait back to update.yaml

### DIFF
--- a/ansible/update.yaml
+++ b/ansible/update.yaml
@@ -26,6 +26,11 @@
         role: '{{ playbook_dir }}/roles/kraken.update/kraken.update.selector',
       }
     - {
+        role: 'roles/kraken.readiness',
+        wait_for_all_hosts: true,
+        tags: [ 'readiness', 'services', 'all', 'ssh_only' ]
+      }
+    - {
         role: 'roles/kraken.ssh/kraken.ssh.selector',
         tags: [ 'ssh', 'all', 'dryrun' ,'ssh_only' ]
       }


### PR DESCRIPTION
we should be waiting for any new nodepools to be created before we
generate the ssh config file