### PR TITLE
Adjusting config.yaml to remove unnecessary mount

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -195,13 +195,8 @@ definitions:
     - &defaultAwsEtcdNode
       name: defaultAwsEtcdNode
       kind: node
-      mounts:
         -
           device: sdf
-          path: /var/lib/docker
-          forceFormat: true
-        -
-          device: sdg
           path: /ephemeral
           forceFormat: false
       providerConfig:
@@ -220,15 +215,6 @@ definitions:
             opts:
               device_name: sdf
               volume_type: gp2
-              volume_size: 100
-              delete_on_termination: true
-              snapshot_id:
-              encrypted: false
-          -
-            type: ebs_block_device
-            opts:
-              device_name: sdg
-              volume_type: gp2
               volume_size: 10
               delete_on_termination: true
               snapshot_id:
@@ -239,10 +225,6 @@ definitions:
       mounts:
         -
           device: sdf
-          path: /var/lib/docker
-          forceFormat: true
-        -
-          device: sdg
           path: /ephemeral
           forceFormat: false
       providerConfig:
@@ -260,15 +242,6 @@ definitions:
             type: ebs_block_device
             opts:
               device_name: sdf
-              volume_type: gp2
-              volume_size: 100
-              delete_on_termination: true
-              snapshot_id:
-              encrypted: false
-          -
-            type: ebs_block_device
-            opts:
-              device_name: sdg
               volume_type: gp2
               volume_size: 10
               delete_on_termination: true

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -195,6 +195,7 @@ definitions:
     - &defaultAwsEtcdNode
       name: defaultAwsEtcdNode
       kind: node
+      mounts:
         -
           device: sdf
           path: /ephemeral


### PR DESCRIPTION
on etcd nodes, docker is not used.  This removes a 100GB EBS volume that serves only to increase someone's aws bill.

Would like it if kraken could support `io1` disk type (needs additional option for iops setting)