### PR TITLE
--api-servers is not needed …

### DIFF
--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -43,8 +43,8 @@
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
-      --node-labels=nodepool={{ node.name }}{% if node.nodeConfig.providerConfig.label is defined %},{% set comma = joiner(",") %}{% for label in node.nodeConfig.providerConfig.label  %}{{ comma() }}{{ label.name }}={{ label.value }}{% endfor %}{% endif %} \
       --hostname-override=${DEFAULT_IPV4} \
+      --require-kubeconfig=true \
       --cluster-dns={{ cluster.dns }} \
       --cluster-domain={{ cluster.domain }} \
       --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -37,8 +37,9 @@
       --stage1-from-dir=stage1-fly.aci \
       docker://{{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }} \
       --exec=/hyperkube -- kubelet \
-      --api_servers=http://127.0.0.1:8080 \
-      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+      --register-node=true \
+      {% if taints_exist == true %}--register-with-taints={% set comma = joiner(",") %}{% for taint in taints  %}{{ comma() }}{{taint.key}}={{taint.value}}:{{taint.effect}}{% endfor %}{% endif %} \
+      --node-labels=nodepool={{ node.name }}{% if node.nodeConfig.providerConfig.label is defined %},{% set comma = joiner(",") %}{% for label in node.nodeConfig.providerConfig.label  %}{{ comma() }}{{ label.name }}={{ label.value }}{% endfor %}{% endif %} \
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -38,7 +38,7 @@
       docker://{{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }} \
       --exec=/hyperkube -- kubelet \
       --register-node=true \
-      {% if taints_exist == true %}--register-with-taints={% set comma = joiner(",") %}{% for taint in taints  %}{{ comma() }}{{taint.key}}={{taint.value}}:{{taint.effect}}{% endfor %}{% endif %} \
+      --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
       --node-labels=nodepool={{ node.name }}{% if node.nodeConfig.providerConfig.label is defined %},{% set comma = joiner(",") %}{% for label in node.nodeConfig.providerConfig.label  %}{{ comma() }}{{ label.name }}={{ label.value }}{% endfor %}{% endif %} \
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kubelet.part.jinja2
@@ -46,6 +46,7 @@
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
+      --require-kubeconfig=true \
       --cluster-dns={{ cluster.dns }} \
       --cluster-domain={{ cluster.domain }} \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kubelet.part.jinja2
@@ -40,7 +40,6 @@
       --stage1-from-dir=stage1-fly.aci \
       docker://{{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }} \
       --exec=/hyperkube -- kubelet \
-      --api_servers=https://apiserver.{{ cluster.name }}.internal \
       --register-node=true \
       {% if taints_exist == true %}--register-with-taints={% set comma = joiner(",") %}{% for taint in taints  %}{{ comma() }}{{taint.key}}={{taint.value}}:{{taint.effect}}{% endfor %}{% endif %} \
       --node-labels=nodepool={{ node.name }}{% if node.nodeConfig.providerConfig.label is defined %},{% set comma = joiner(",") %}{% for label in node.nodeConfig.providerConfig.label  %}{{ comma() }}{{ label.name }}={{ label.value }}{% endfor %}{% endif %} \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/v1.5/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/v1.5/units.kubelet.part.jinja2
@@ -45,6 +45,7 @@
       --allow-privileged=true \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
+      --require-kubeconfig=true \
       --cluster-dns={{ cluster.dns }} \
       --cluster-domain={{ cluster.domain }} \
       --tls-cert-file=/etc/kubernetes/ssl/worker.pem \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/v1.5/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/v1.5/units.kubelet.part.jinja2
@@ -40,7 +40,6 @@
       --stage1-from-dir=stage1-fly.aci \
       docker://{{ node.kubeConfig.hyperkubeLocation }}:{{ node.kubeConfig.version }} \
       --exec=/hyperkube -- kubelet \
-      --api_servers=https://apiserver.{{ cluster.name }}.internal \
       --register-node=true \
       --node-labels=nodepool={{ node.name }}{% if node.nodeConfig.providerConfig.label is defined %},{% set comma = joiner(",") %}{% for label in node.nodeConfig.providerConfig.label  %}{{ comma() }}{{ label.name }}={{ label.value }}{% endfor %}{% endif %} \
       --allow-privileged=true \


### PR DESCRIPTION
… if kubeconfig is provided and indicates api-server, this is deprecated and breaks in v1.8

This answers #778 