### PR TITLE
add batch/v2alpha1 for cronjobs

### DIFF
--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
@@ -33,6 +33,7 @@ spec:
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --cloud-provider={{cluster.providerConfig.provider}}
     - --logtostderr=true
+    - --runtime-config=batch/v2alpha1=true 
 {% if cluster.kubeAuth.authn.oidc is defined %}
     - --oidc-issuer-url={{cluster.kubeAuth.authn.oidc.issuer}}
     - --oidc-client-id=example-app

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.5/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.5/api-server-manifest.yaml.jinja2
@@ -33,6 +33,7 @@ spec:
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --cloud-provider={{cluster.providerConfig.provider}}
     - --logtostderr=true
+    - --runtime-config=batch/v2alpha1=true 
 {% if cluster.kubeAuth.authn.oidc is defined %}
     - --oidc-issuer-url={{cluster.kubeAuth.authn.oidc.issuer}}
     - --oidc-client-id=example-app

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -33,6 +33,7 @@ spec:
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --cloud-provider={{cluster.providerConfig.provider}}
     - --logtostderr=true
+    - --runtime-config=batch/v2alpha1=true 
 {% if cluster.kubeAuth.authn.oidc is defined %}
     - --oidc-issuer-url={{cluster.kubeAuth.authn.oidc.issuer}}
     - --oidc-client-id=example-app

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/api-server-manifest.yaml.jinja2
@@ -33,6 +33,7 @@ spec:
     - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
     - --cloud-provider={{cluster.providerConfig.provider}}
     - --logtostderr=true
+    - --runtime-config=batch/v2alpha1=true 
 {% if cluster.kubeAuth.authn.oidc is defined %}
     - --oidc-issuer-url={{cluster.kubeAuth.authn.oidc.issuer}}
     - --oidc-client-id=example-app


### PR DESCRIPTION
this is necessary in kubernetes versions >= 1.8 to enable cronjobs, which will be needed for curator (for logging) to wipe out old logs and keep out ES pods up and running. 

Note*    CronJob resource in batch/v2alpha1 API group has been deprecated starting from cluster version 1.8. We will need to switch to using batch/v1beta1, instead, which will be enabled by default in the API server.