### PR TITLE
helm appr pathing sorted

### DIFF
--- a/ansible/roles/kraken.services/tasks/kill-services.yaml
+++ b/ansible/roles/kraken.services/tasks/kill-services.yaml
@@ -7,9 +7,16 @@
   set_fact:
     cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
     cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
+    helm_command: "{{ helm_commands[cluster.name] }}"
+    helm_home: "{{ config_base }}/{{ cluster.name }}/.helm"
     kubeconfig: "{{ config_base }}/{{ cluster.name }}/admin.kubeconfig"
     kubectl: "{{ kubectl_commands[cluster.name] }}"
     cluster_namespaces: []
+
+- name: Set dependent facts
+  set_fact:
+    helm_path: "{{ helm_command | dirname }}"
+
 
 - name: Build a list of namespaces used for services
   set_fact:
@@ -30,10 +37,11 @@
 
 - name: Clean up releases
   command: >
-    {{ helm_commands[cluster.name] }} delete --purge {{ item.name }}
+    {{ helm_command }} delete --purge {{ item.name }}
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
-    HELM_HOME: "{{ helm_homes[cluster.name] }}"
+    HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_services }}"
   ignore_errors: yes
   when:

--- a/ansible/roles/kraken.services/tasks/manage-services.yaml
+++ b/ansible/roles/kraken.services/tasks/manage-services.yaml
@@ -7,10 +7,14 @@
   set_fact:
     cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
     cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
-    helm_command: "{{ helm_commands[cluster.name] }}"
+    helm_command: "{{ helm_commands[cluster.name] }}"        
     kubectl: "{{ kubectl_commands[cluster.name] }}"
     kubeconfig: "{{ config_base }}/{{ cluster.name }}/admin.kubeconfig"
     helm_home: "{{ config_base }}/{{ cluster.name }}/.helm"
+
+- name: Set dependent facts
+  set_fact:
+    helm_path: "{{ helm_command | dirname }}"
 
 - name: Get helm and tiller versions
   command: >
@@ -19,6 +23,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   changed_when: false
 
 - name: Upgrade tiller
@@ -27,6 +32,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   when:
     - (helm_versions.stdout_lines | length) == 2
     - (helm_versions.stdout_lines[0] | regex_replace(regex)) != (helm_versions.stdout_lines[1] | regex_replace(regex))
@@ -47,6 +53,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_repos }}"
   when:
     - cluster_repos is defined
@@ -60,6 +67,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_repos }}"
   when:
     - cluster_repos is defined
@@ -91,6 +99,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_services }}"
   when:
     - cluster_services is defined
@@ -106,6 +115,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_services }}"
   when:
     - cluster_services is defined

--- a/ansible/roles/kraken.services/tasks/manage-services.yaml
+++ b/ansible/roles/kraken.services/tasks/manage-services.yaml
@@ -7,7 +7,7 @@
   set_fact:
     cluster_services: "{{ cluster.helmConfig.charts | default([]) }}"
     cluster_repos: "{{ cluster.helmConfig.repos | default([]) }}"
-    helm_command: "{{ helm_commands[cluster.name] }}"        
+    helm_command: "{{ helm_commands[cluster.name] }}"
     kubectl: "{{ kubectl_commands[cluster.name] }}"
     kubeconfig: "{{ config_base }}/{{ cluster.name }}/admin.kubeconfig"
     helm_home: "{{ config_base }}/{{ cluster.name }}/.helm"

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -13,6 +13,10 @@
     kubeconfig: "{{ config_base }}/{{ cluster.name }}/admin.kubeconfig"
     kubectl: "{{ kubectl_commands[cluster.name] }}"
 
+- name: Set dependent facts
+  set_fact:
+    helm_path: "{{ helm_command | dirname }}"
+
 - name: create debug helm command string
   set_fact:
     helm_command: "{{ helm_command }} --debug"
@@ -43,6 +47,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   register: init_dry_out
   when:
     - cluster.helmConfig.debug is defined
@@ -55,6 +60,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   retries: 60
   delay: 1
   when: helm_command is defined
@@ -74,6 +80,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_repos }}"
   when:
     - cluster_repos is defined
@@ -87,6 +94,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_repos }}"
   when:
     - cluster_repos is defined
@@ -98,6 +106,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_registries }}"
   when: cluster_registries is defined and (helm_command is defined)
 
@@ -128,6 +137,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_services }}"
   register: install_dry_out
   when:
@@ -146,6 +156,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_services }}"
   when:
     - cluster_services is defined
@@ -161,6 +172,7 @@
   environment:
     KUBECONFIG: "{{ kubeconfig }}"
     HELM_HOME: "{{ helm_home }}"
+    PATH: "{{ helm_path }}:{{ ansible_env.PATH }}"
   with_items: "{{ cluster_services }}"
   when:
     - cluster_services is defined


### PR DESCRIPTION
this change allows the app registry plugin to execute the epxected
version of helm when it runs.  the app registry plugin is called
from helm via `helm appr` and it will make a call back to helm via
a shell invocation `helm`.  This means app registry will execute
whichever helm it finds in the system path.  We don't want this.

we now put the path for the calling helm at the front of the system
path so it gets called by the app registry plugin