### PR TITLE
Changed max len of cluster name to not hit max len for AWS ELB name 

### DIFF
--- a/schemas/config/v1/cluster.json
+++ b/schemas/config/v1/cluster.json
@@ -10,7 +10,7 @@
       "description": "Name of this cluster.",
       "type": "string",
       "pattern": "^[A-Za-z0-9-]+$",
-      "maxLength": 32,
+      "maxLength": 21,
       "minLength": 1
     },
     "network": {


### PR DESCRIPTION
Change max length for cluster names to 21. AWS ELB name max length is 32 and we append `-master-elb` which add 11 chars. 

Fixes: https://github.com/samsung-cnct/kraken-lib/issues/883