### PR TITLE
Use cert specifically for kube-proxy

### DIFF
--- a/ansible/roles/kraken.config/defaults/main.yaml
+++ b/ansible/roles/kraken.config/defaults/main.yaml
@@ -4,3 +4,4 @@ config_base: "~/.kraken"
 config_file_default: "{{ config_base }}/config.yaml"
 config_file: "{{ config_path | default(config_file_default) }}"
 dryrun: false
+drunkensmee: "quay.io/samsung_cnct/drunkensmee-container:e0e0c05"

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/etcd.units.kraken-etcd-ssl.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/etcd.units.kraken-etcd-ssl.part.jinja2
@@ -20,6 +20,6 @@
      --set-env=HOST_IP=${DEFAULT_IPV4} \
      --set-env=SERVICE_DNS_NAME={{ cluster_node_tuple.1.name }}.{{ cluster_node_tuple.0.name }}.internal \
      --set-env=HOST_DNS_NAME=*.{{ cluster_node_tuple.1.name }}.{{ cluster_node_tuple.0.name }}.internal \
-     quay.io/samsung_cnct/drunkensmee:v0.6 \
+     {{ drunkensmee }} \
      --exec /assets/generate_etcd.sh
     ExecStopPost=/usr/bin/rkt gc --mark-only

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/v1.5/etcd.units.kraken-etcd-ssl.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/v1.5/etcd.units.kraken-etcd-ssl.part.jinja2
@@ -20,6 +20,6 @@
      --set-env=HOST_IP=${DEFAULT_IPV4} \
      --set-env=SERVICE_DNS_NAME={{ cluster_node_tuple.1.name }}.{{ cluster_node_tuple.0.name }}.internal \
      --set-env=HOST_DNS_NAME=*.{{ cluster_node_tuple.1.name }}.{{ cluster_node_tuple.0.name }}.internal \
-     quay.io/samsung_cnct/drunkensmee:v0.5 \
+     {{ drunkensmee }} \
      --exec /assets/generate_etcd.sh
     ExecStopPost=/usr/bin/rkt gc --mark-only

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/tasks/each-cluster-nodepool.yaml
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/tasks/each-cluster-nodepool.yaml
@@ -10,6 +10,7 @@
   include: cloud_config/write_files.yaml
   with_items:
     - kubeconfig.jinja2
+    - proxy-kubeconfig.jinja2
     - api-server-manifest.yaml.jinja2
     - controller-manager-manifest.yaml.jinja2
     - kube-proxy-manifest.yaml.jinja2

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/proxy-kubeconfig.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/proxy-kubeconfig.jinja2
@@ -1,0 +1,20 @@
+- path: /etc/kubernetes/proxy-kubeconfig.yaml
+  content: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: {{ cluster.name }}
+      cluster:
+        certificate-authority: /etc/kubernetes/ssl/ca.pem
+        server: https://apiserver.{{ cluster.name }}.internal
+    users:
+    - name: proxy
+      user:
+        client-certificate: /etc/kubernetes/ssl/proxy.pem
+        client-key: /etc/kubernetes/ssl/proxy-key.pem
+    contexts:
+    - context:
+        cluster: {{ cluster.name }}
+        user: proxy
+      name: proxy-context
+    current-context: proxy-context

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kraken-apiserver-ssl.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kraken-apiserver-ssl.part.jinja2
@@ -23,6 +23,6 @@
      {% if cluster.customApiDns is defined %}
         --set-env=CUSTOM_API_DNS={{ cluster.customApiDns }} \
      {% endif %}
-     quay.io/samsung_cnct/drunkensmee:v0.6 \
+     {{ drunkensmee }} \
      --exec /assets/generate_apiserver.sh
     ExecStopPost=/usr/bin/rkt gc --mark-only

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.5/units.kraken-apiserver-ssl.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.5/units.kraken-apiserver-ssl.part.jinja2
@@ -20,6 +20,6 @@
      --set-env=HOST_IP=${DEFAULT_IPV4} \
      --set-env=KUBE_SERVICE_IP={{ cluster.network | ipaddr('1') | ipaddr('address') }} \
      --set-env=SERVICE_DNS_NAME=apiserver.{{ cluster.name }}.internal \
-     quay.io/samsung_cnct/drunkensmee:v0.5 \
+     {{ drunkensmee }} \
      --exec /assets/generate_apiserver.sh
     ExecStopPost=/usr/bin/rkt gc --mark-only

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/tasks/each-cluster-nodepool.yaml
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/tasks/each-cluster-nodepool.yaml
@@ -10,6 +10,7 @@
   with_items:
     - kube-proxy-manifest.yaml.jinja2
     - kubeconfig.jinja2
+    - proxy-kubeconfig.jinja2
 
 - name: Create cloud_config units for worker nodes
   include: cloud_config/units.yaml

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/kube-proxy-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/kube-proxy-manifest.yaml.jinja2
@@ -16,14 +16,14 @@
         - /hyperkube
         - proxy
         - --master=https://apiserver.{{ cluster.name }}.internal
-        - --kubeconfig=/etc/kubernetes/kubeconfig.yaml
+        - --kubeconfig=/etc/kubernetes/proxy-kubeconfig.yaml
         - --proxy-mode=iptables
         securityContext:
           privileged: true
         volumeMounts:
           - mountPath: /etc/ssl/certs
             name: "ssl-certs"
-          - mountPath: /etc/kubernetes/kubeconfig.yaml
+          - mountPath: /etc/kubernetes/proxy-kubeconfig.yaml
             name: "kubeconfig"
             readOnly: true
           - mountPath: /etc/kubernetes/ssl
@@ -35,7 +35,7 @@
             path: "/usr/share/ca-certificates"
         - name: "kubeconfig"
           hostPath:
-            path: "/etc/kubernetes/kubeconfig.yaml"
+            path: "/etc/kubernetes/proxy-kubeconfig.yaml"
         - name: "etc-kube-ssl"
           hostPath:
             path: "/etc/kubernetes/ssl"

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/proxy-kubeconfig.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/proxy-kubeconfig.jinja2
@@ -1,0 +1,20 @@
+- path: /etc/kubernetes/proxy-kubeconfig.yaml
+  content: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: {{ cluster.name }}
+      cluster:
+        certificate-authority: /etc/kubernetes/ssl/ca.pem
+        server: https://apiserver.{{ cluster.name }}.internal
+    users:
+    - name: proxy
+      user:
+        client-certificate: /etc/kubernetes/ssl/proxy.pem
+        client-key: /etc/kubernetes/ssl/proxy-key.pem
+    contexts:
+    - context:
+        cluster: {{ cluster.name }}
+        user: proxy
+      name: proxy-context
+    current-context: proxy-context

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kraken-worker-ssl.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kraken-worker-ssl.part.jinja2
@@ -18,6 +18,6 @@
      --mount volume=input,target=/input \
      --mount volume=output,target=/output \
      --set-env=HOST_IP=${DEFAULT_IPV4} \
-     quay.io/samsung_cnct/drunkensmee:v0.6 \
+     {{ drunkensmee }} \
      --exec /assets/generate_worker.sh
     ExecStopPost=/usr/bin/rkt gc --mark-only

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/v1.5/units.kraken-worker-ssl.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/v1.5/units.kraken-worker-ssl.part.jinja2
@@ -18,6 +18,6 @@
      --mount volume=input,target=/input \
      --mount volume=output,target=/output \
      --set-env=HOST_IP=${DEFAULT_IPV4} \
-     quay.io/samsung_cnct/drunkensmee:v0.5 \
+     {{ drunkensmee }} \
      --exec /assets/generate_worker.sh
     ExecStopPost=/usr/bin/rkt gc --mark-only


### PR DESCRIPTION
kubelet and kube-proxy were sharing the same kubeconfig. Using the
correct username (CN) and group (O) in the node cert breaks kube-proxy.
This creates a cert specifically for kube-proxy.

This PR requires changes in drunkensmee (The referenced container tag is
the github commit sha).