### PR TITLE
Change arguments to hack/e2e.go to account for single letter

### DIFF
--- a/hack/parallel-conformance.sh
+++ b/hack/parallel-conformance.sh
@@ -46,7 +46,7 @@ function run_hack_e2e_go() {
   
   # run everything that we can in 
   cd ${KUBE_ROOT}
-  GINKGO_NO_COLOR=y GINKGO_PARALLEL=y go run hack/e2e.go -- -v --test --test_args="${common_test_args[*]} ${test_args[*]}" --check-version-skew=false
+  GINKGO_NO_COLOR=y GINKGO_PARALLEL=y go run hack/e2e.go -- --v --test --test_args="${common_test_args[*]} ${test_args[*]}" --check-version-skew=false
 }
 
 echo


### PR DESCRIPTION
arguments requiring two dashs.