### PR TITLE
Tiller namespace

### DIFF
--- a/ansible/roles/kraken.services/files/helm-rbac-config.yaml
+++ b/ansible/roles/kraken.services/files/helm-rbac-config.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tiller
-    namespace: kraken 
+    namespace: kraken

--- a/ansible/roles/kraken.services/files/helm-rbac-config.yaml
+++ b/ansible/roles/kraken.services/files/helm-rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kraken
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kraken 

--- a/ansible/roles/kraken.services/files/kraken-namespace.yaml
+++ b/ansible/roles/kraken.services/files/kraken-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kraken

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -25,22 +25,48 @@
     - cluster.helmConfig.debug == True
     - helm_command is defined
 
+#########################################################
+
+- name: create kraken namespace
+  command: >
+    {{ kubectl }} --kubeconfig={{ kubeconfig }} apply -f  "{{ item }}"
+  with_first_found:
+    - files:
+      - /kraken/ansible/roles/kraken.services/files/kraken-namespace.yaml
+      skip: true 
+
+- name: Create tiller service account
+  command: >
+    {{ kubectl }} --kubeconfig={{ kubeconfig }} create serviceaccount tiller --namespace kraken
+
+- name: pre-reqs for helm serviceaccount and rbac
+  command: >
+    {{ kubectl }} --kubeconfig={{ kubeconfig }} apply -f "{{ item }}" --record
+  with_first_found:
+    - files:
+      - /kraken/ansible/roles/kraken.services/files/helm-rbac-config.yaml
+      skip: true
+
 - name: create helm init command string
   set_fact:
-    helm_init_command: "{{ helm_command }} init"
+  #  helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }}"
+    helm_init_command: "{{ helm_command init --service-account tiller --tiller-namespace kraken}}"
   when:
     - ((tiller_image is undefined) or (tiller_image is none) or (tiller_image | trim == ''))
     - helm_command is defined
 
+
 - name: create helm init command string
   set_fact:
-    helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }}"
+    helm_init_command: "{{ helm_command init --service-account tiller --tiller-namespace kraken}}"
+    # helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }}"
   when:
     - tiller_image is defined
     - tiller_image is not none
     - tiller_image | trim != ''
     - helm_command is defined
 
+    #################################################################
 - name: Init helm dry-run
   command: >
     {{ helm_init_command }} --dry-run
@@ -66,7 +92,7 @@
   when: helm_command is defined
 
 - name: Wait for tiller to be ready
-  command: "{{ kubectl }} --kubeconfig={{ kubeconfig }} --namespace=kube-system get deploy tiller-deploy -o json"
+  command: "{{ kubectl }} --kubeconfig={{ kubeconfig }} --namespace=kraken get deploy tiller-deploy -o json"
   register: output
   until: (output | succeeded) and ((output.stdout | from_json).status.availableReplicas | default(0)) > 0
   retries: 600

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -25,48 +25,36 @@
     - cluster.helmConfig.debug == True
     - helm_command is defined
 
-#########################################################
-
 - name: create kraken namespace
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig }} apply -f  "{{ item }}"
   with_first_found:
     - files:
-      - /kraken/ansible/roles/kraken.services/files/kraken-namespace.yaml
-      skip: true 
+      - kraken-namespace.yaml
 
-- name: Create tiller service account
-  command: >
-    {{ kubectl }} --kubeconfig={{ kubeconfig }} create serviceaccount tiller --namespace kraken
-
-- name: pre-reqs for helm serviceaccount and rbac
+- name: setup rbac and serviceaccount for tiller
   command: >
     {{ kubectl }} --kubeconfig={{ kubeconfig }} apply -f "{{ item }}" --record
   with_first_found:
     - files:
-      - /kraken/ansible/roles/kraken.services/files/helm-rbac-config.yaml
-      skip: true
+      - helm-rbac-config.yaml
 
 - name: create helm init command string
   set_fact:
-  #  helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }}"
-    helm_init_command: "{{ helm_command init --service-account tiller --tiller-namespace kraken}}"
+    helm_init_command: "{{ helm_command }} init --service-account tiller --tiller-namespace kraken "
   when:
     - ((tiller_image is undefined) or (tiller_image is none) or (tiller_image | trim == ''))
     - helm_command is defined
 
-
 - name: create helm init command string
   set_fact:
-    helm_init_command: "{{ helm_command init --service-account tiller --tiller-namespace kraken}}"
-    # helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }}"
+    helm_init_command: "{{ helm_command }} init --tiller-image {{ tiller_image }} --service-account tiller --tiller-namespace kraken "
   when:
     - tiller_image is defined
     - tiller_image is not none
     - tiller_image | trim != ''
     - helm_command is defined
 
-    #################################################################
 - name: Init helm dry-run
   command: >
     {{ helm_init_command }} --dry-run
@@ -155,6 +143,7 @@
 - name: Install charts dry-run
   command: >
     {{ helm_command }} install {{ item.repo }}/{{ item.chart }}
+      --tiller-namespace kraken
       --name {{ item.name }}
       --version {{ item.version }}
       --namespace {{ item.namespace | default('default') }}
@@ -175,6 +164,7 @@
 - name: Install charts from repo
   command: >
     {{ helm_command }} install {{ item.repo }}/{{ item.chart }}
+      --tiller-namespace kraken
       --name {{ item.name }}
       --version {{ item.version }}
       --namespace {{ item.namespace | default('default') }}
@@ -191,7 +181,8 @@
 
 - name: Install charts from registry
   command: >
-    {{ helm_command }} registry install {{ item.registry }}/{{ item.chart }}@{{ item.version }} --
+    {{ helm_command }} registry install {{ item.registry }}/{{ item.chart }}@{{ item.version }}  --
+      --tiller-namespace kraken
       --name {{ item.name }}
       --namespace {{ item.namespace | default('default') }}
       --values {{ config_base }}/{{ cluster.name }}/{{ item.registry }}-{{ item.name | replace('/','_') }}.helmvalues

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -27,7 +27,7 @@
 
 - name: create kraken namespace
   command: >
-    {{ kubectl }} --kubeconfig={{ kubeconfig }} apply -f  "{{ item }}"
+    {{ kubectl }} --kubeconfig={{ kubeconfig }} apply -f  "{{ item }}" --record
   with_first_found:
     - files:
       - kraken-namespace.yaml

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -31,6 +31,7 @@
   with_first_found:
     - files:
       - kraken-namespace.yaml
+  when: helm_command is defined
 
 - name: setup rbac and serviceaccount for tiller
   command: >
@@ -38,6 +39,8 @@
   with_first_found:
     - files:
       - helm-rbac-config.yaml
+      skip: true
+  when: helm_command is defined
 
 - name: create helm init command string
   set_fact:


### PR DESCRIPTION
this will install till into a `--tiller-namespace` of `kraken`. Currently it is setup to run tiller as a cluster-admin, giving it permission over all namespaces.  We can change this if folks want, to instead give it access only over `kraken`, `kube-networking`, `kube-system`, and any other namespaces listed in `helmConfigs`.  We could also open another ticket if we think this is good enough for now. 

I would love feedback on if anyone thinks it is necessary to change the info at cluster creation given to a user who runs `dockerdev`, seeing as right now the old: `to use helm`... isn't going to give them access to the releases.  They would need to be instructed to add `--tiler-namespace kraken` to their helm command. 