### PR TITLE
correct depth for returning fabric

### DIFF
--- a/ansible/library/compatibility.py
+++ b/ansible/library/compatibility.py
@@ -79,7 +79,7 @@ def get_versioned_fabric(fabric_config, version):
         if version_key in fabric_config['kubeVersion']['versions']:
             return fabric_config['kubeVersion']['versions'][version_key]
         else:
-            return fabric_config['default']
+            return fabric_config['kubeVersion']['default']
     else:
         return fabric_config
 


### PR DESCRIPTION
was missing a level on the mapping to return the default fabric in
the case of using a 1.7 default version of kubernetes