### PR TITLE
Added back 'services_only' tag

### DIFF
--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -49,7 +49,7 @@
       }
     - {
         role: 'roles/kraken.services',
-        tags: [ 'services', 'all', 'dns_only' ]
+        tags: [ 'services', 'services_only', 'all', 'dns_only' ]
       }
     - {
         role: 'roles/kraken.post',


### PR DESCRIPTION
`services_only` was removed: https://github.com/samsung-cnct/kraken-lib/pull/488

I hit a dev edge case where I really needed `services_only`. Adding it back in. 

It's also still in the documentation.