### PR TITLE
Fix etcd health check so that all results are reported and multiple

### DIFF
--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
@@ -58,9 +58,10 @@
   include_role:
     name: kraken.ssh/kraken.ssh.aws
 
-- name: Wait for etcd nodes to form cluster
+- name: Wait for etcd nodes to form clusters
   include: wait-for-etcd.yaml
-  with_items: "{{ cluster.nodePools }}"
+  with_items:
+    - "{{ cluster.nodePools }}"
   loop_control:
     loop_var: nodePool
   when:

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-etcd.yaml
@@ -1,48 +1,7 @@
 ---
-- set_fact:
-    ssh_config: "{{ config_base }}/{{ cluster.name }}/ssh_config"
-    etcd_loopback_endpoints: "{% for etcd in nodePool.etcdConfigs %}{% for port in etcd.clientPorts %}{% if etcd.ssl == true %}https{% else %}http{% endif %}://127.0.0.1:{{ port }}{{ ',' if not loop.last else '' }}{% endfor %}{% endfor %}"
-
-# We purposely use ssh to query etcd over the loopback interface.
-# This allows us to support stricter firewall rules.
-- name: Wait for etcd cluster to form ({{ nodePool.name }})
-  command: >
-    ssh -o StrictHostKeyChecking=no
-        -o UserKnownHostsFile=/dev/null
-        -F {{ ssh_config }} {{ nodePool.name }}-{{ idx }}
-        etcdctl --ca-file={{ etcd_cafile }}
-                --cert-file={{ etcd_certfile }}
-                --key-file={{ etcd_keyfile }}
-                --endpoints={{ etcd_loopback_endpoints }}
-                   cluster-health
-  register: etcd_result
-  until: etcd_result | succeeded
-  retries: "{{ etcd_retries }}"
-  delay: "{{ etcd_delay }}"
-  with_items: "{{ nodePool.count }}"
+- name: Wait for all etcd clusters in the nodePool named {{ nodePool.name }} to form
+  include: wait-for-one-etcd.yaml
+  with_items:
+    - "{{ nodePool.etcdConfigs }}"
   loop_control:
-    loop_var: idx
-  # See k2/674 for notes on the correct fix to eliminating this when statement.
-  when: nodePool.nodeConfig.providerConfig.enablePublicIPs is undefined or
-        nodePool.nodeConfig.providerConfig.enablePublicIPs
-
-- debug:
-    var: etcd_result
-    verbosity: 0
-
-- name: Fail if any etcd node failed to report healthy
-  fail:
-    msg: >
-      An etcd node failed to report a healthy status. Please run down and
-      reattempt to run up again.
-  when: etcd_result | failed
-
-# When we have no other way to determine etcd cluster health, wait the maximum
-# expected time. See k2/674 for notes on the correct fix to eliminating this
-# pause.
-- name: Pause when traditional etcd health checks are unavailable
-  pause:
-    seconds: "{{ (etcd_retries * etcd_delay) | int }}"
-  when:
-    - nodePool.nodeConfig.providerConfig.enablePublicIPs is defined
-    - not nodePool.nodeConfig.providerConfig.enablePublicIPs
+    loop_var: etcdConfig

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
@@ -19,6 +19,7 @@
     ssh -o StrictHostKeyChecking=no
         -o UserKnownHostsFile=/dev/null
         -F {{ ssh_config }} {{ nodePool.name }}-1
+        export ETCDCTL_API=3 &&
         etcdctl --ca-file={{ etcd_cafile }}
                 --cert-file={{ etcd_certfile }}
                 --key-file={{ etcd_keyfile }}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
@@ -1,44 +1,49 @@
 ---
 - set_fact:
     ssh_config: "{{ config_base }}/{{ cluster.name }}/ssh_config"
-    etcd_loopback_endpoints: "{% for port in etcdConfig.clientPorts %}{% if etcdConfig.ssl == true %}https{% else %}http{% endif %}://127.0.0.1:{{ port }}{{ ',' if not loop.last else '' }}{% endfor %}"
+    etcd_loopback_endpoints: "
+      {%- for port in etcdConfig.clientPorts -%}
+        {%- if etcdConfig.ssl == true -%}
+          https
+        {%- else -%}
+          http
+        {%- endif -%}
+          ://127.0.0.1:{{ port }}
+        {{- ',' if not loop.last else '' -}}
+      {%- endfor -%}"
 
 # We purposely use ssh to query etcd over the loopback interface.
-# This allows us to support stricter firewall rules. We need to
-# check each etcd node because older versions of etcdctl would
-# report success when the local node was healthy, but the
-# entire cluster was not necessarily so.
+# This allows us to support stricter firewall rules.
 - name: Wait for etcd cluster {{ etcdConfig.name }} to form within nodePool {{ nodePool.name }}
   command: >
     ssh -o StrictHostKeyChecking=no
         -o UserKnownHostsFile=/dev/null
-        -F {{ ssh_config }} {{ nodePool.name }}-{{ idx }}
+        -F {{ ssh_config }} {{ nodePool.name }}-1
         etcdctl --ca-file={{ etcd_cafile }}
                 --cert-file={{ etcd_certfile }}
                 --key-file={{ etcd_keyfile }}
                 --endpoints={{ etcd_loopback_endpoints }}
-                  cluster-health
-  register: etcd_result
-  until: etcd_result | succeeded
+                member list
+  register: etcdctl_result
+  until: etcdctl_result.stdout_lines | list | length == nodePool.count
   retries: "{{ etcd_retries }}"
   delay: "{{ etcd_delay }}"
-  with_sequence: start=1 end={{ nodePool.count }}
-  loop_control:
-    loop_var: idx
+  ignore_errors: yes
   # See k2/674 for notes on the correct fix to eliminating this when statement.
   when: nodePool.nodeConfig.providerConfig.enablePublicIPs is undefined or
         nodePool.nodeConfig.providerConfig.enablePublicIPs
 
 - debug:
-    var: etcd_result
+    var: etcdctl_result
     verbosity: 0
 
-- name: Fail if any etcd node failed to report healthy
+- name: Fail if there were fewer members of the etcd cluster {{ etcdConfig.name }} than expected
   fail:
     msg: >
-      An etcd node failed to report a healthy status. Please run down and
-      reattempt to run up again.
-  when: etcd_result | failed
+     Expected {{ nodePool.count }} members of the etcd cluster
+     {{ etcdConfig.name }}, but only found {{ etcdctl_result.stdout_lines | list | length }}
+     members. Please run down and reattempt to run up again.
+  when: etcdctl_result.stdout_lines | list | length != nodePool.count
 
 # When we have no other way to determine etcd cluster health, wait the maximum
 # expected time. See k2/674 for notes on the correct fix to eliminating this

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
@@ -19,7 +19,6 @@
     ssh -o StrictHostKeyChecking=no
         -o UserKnownHostsFile=/dev/null
         -F {{ ssh_config }} {{ nodePool.name }}-1
-        export ETCDCTL_API=3 &&
         etcdctl --ca-file={{ etcd_cafile }}
                 --cert-file={{ etcd_certfile }}
                 --key-file={{ etcd_keyfile }}

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/wait-for-one-etcd.yaml
@@ -1,0 +1,51 @@
+---
+- set_fact:
+    ssh_config: "{{ config_base }}/{{ cluster.name }}/ssh_config"
+    etcd_loopback_endpoints: "{% for port in etcdConfig.clientPorts %}{% if etcdConfig.ssl == true %}https{% else %}http{% endif %}://127.0.0.1:{{ port }}{{ ',' if not loop.last else '' }}{% endfor %}"
+
+# We purposely use ssh to query etcd over the loopback interface.
+# This allows us to support stricter firewall rules. We need to
+# check each etcd node because older versions of etcdctl would
+# report success when the local node was healthy, but the
+# entire cluster was not necessarily so.
+- name: Wait for etcd cluster {{ etcdConfig.name }} to form within nodePool {{ nodePool.name }}
+  command: >
+    ssh -o StrictHostKeyChecking=no
+        -o UserKnownHostsFile=/dev/null
+        -F {{ ssh_config }} {{ nodePool.name }}-{{ idx }}
+        etcdctl --ca-file={{ etcd_cafile }}
+                --cert-file={{ etcd_certfile }}
+                --key-file={{ etcd_keyfile }}
+                --endpoints={{ etcd_loopback_endpoints }}
+                  cluster-health
+  register: etcd_result
+  until: etcd_result | succeeded
+  retries: "{{ etcd_retries }}"
+  delay: "{{ etcd_delay }}"
+  with_sequence: start=1 end={{ nodePool.count }}
+  loop_control:
+    loop_var: idx
+  # See k2/674 for notes on the correct fix to eliminating this when statement.
+  when: nodePool.nodeConfig.providerConfig.enablePublicIPs is undefined or
+        nodePool.nodeConfig.providerConfig.enablePublicIPs
+
+- debug:
+    var: etcd_result
+    verbosity: 0
+
+- name: Fail if any etcd node failed to report healthy
+  fail:
+    msg: >
+      An etcd node failed to report a healthy status. Please run down and
+      reattempt to run up again.
+  when: etcd_result | failed
+
+# When we have no other way to determine etcd cluster health, wait the maximum
+# expected time. See k2/674 for notes on the correct fix to eliminating this
+# pause.
+- name: Pause when traditional etcd health checks are unavailable
+  pause:
+    seconds: "{{ (etcd_retries * etcd_delay) | int }}"
+  when:
+    - nodePool.nodeConfig.providerConfig.enablePublicIPs is defined
+    - not nodePool.nodeConfig.providerConfig.enablePublicIPs


### PR DESCRIPTION
etcd instances running on the same node will all be checked.
Fixes #702.
