### PR TITLE
Update default k8s version for GKE to 1.7.8 to avoid auto-upgrade

### DIFF
--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -123,7 +123,7 @@ definitions:
     - &defaultKube
       name: defaultKube
       kind: kubernetes
-      version: v1.7.6
+      version: v1.7.8
       hyperkubeLocation: gcr.io/google_containers/hyperkube
   containerConfigs:
     - &defaultDocker


### PR DESCRIPTION
during cluster creation.