### PR TITLE
Removed 1.5 super_user references

### DIFF
--- a/Documentation/security/README.md
+++ b/Documentation/security/README.md
@@ -41,10 +41,7 @@ definitions:
         super_user: admin
    - &rbacKubeAuth
       authz:
-        rbac:
-         # super_user is required until kubernetes 1.5 is no longer supported by k2.
-         # It is not used by kubernetes 1.6 or later.
-          super_user: "placeholder"
+        rbac: {}
       authn:
         cert:
           -

--- a/Documentation/security/example/config.yaml
+++ b/Documentation/security/example/config.yaml
@@ -76,5 +76,4 @@ definitions:
       - user: admin
         password: secret
     authz:
-      rbac:
-        super_user: admin
+      rbac: {}

--- a/ansible/roles/kraken.config/files/config-private-topology.yaml
+++ b/ansible/roles/kraken.config/files/config-private-topology.yaml
@@ -477,10 +477,7 @@ definitions:
         default_basic_user: "admin"
    - &rbacKubeAuth
       authz:
-        rbac:
-          # super_user is required until kubernetes 1.5 is no longer supported by k2.
-          # It is not used by kubernetes 1.6 or later.
-          super_user: "placeholder"
+        rbac: {}
       authn:
         cert:
           -

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -370,10 +370,7 @@ definitions:
         default_basic_user: "admin"
    - &rbacKubeAuth
       authz:
-        rbac:
-          # super_user is required until kubernetes 1.5 is no longer supported by k2.
-          # It is not used by kubernetes 1.6 or later.
-          super_user: "placeholder"
+        rbac: {}
       authn:
         cert:
           -

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -175,10 +175,7 @@ definitions:
         default_basic_user: "admin"
    - &rbacKubeAuth
       authz:
-        rbac:
-          # super_user is required until kubernetes 1.5 is no longer supported by k2.
-          # It is not used by kubernetes 1.6 or later.
-          super_user: "placeholder"
+        rbac: {}
       authn:
         cert:
           -

--- a/docs/index.html
+++ b/docs/index.html
@@ -3387,18 +3387,6 @@
 </tr>
 <tr class="row-odd"><td colspan="3">properties</td>
 </tr>
-<tr class="row-even"><td rowspan="3"><ul class="first last simple">
-<li>super_user</li>
-</ul>
-</td>
-<td colspan="2">Determines the authorization-rbac-super-user flag used to start the apiserver in versions of kubernetes &lt;= 1.5</td>
-</tr>
-<tr class="row-odd"><td>type</td>
-<td><em>string</em></td>
-</tr>
-<tr class="row-even"><td>default</td>
-<td>placeholder</td>
-</tr>
 </tbody>
 </table>
 </div>

--- a/schemas/config/v1/kubeAuthAuthzEntry.json
+++ b/schemas/config/v1/kubeAuthAuthzEntry.json
@@ -9,14 +9,7 @@
     "rbac": {
       "description": "Kubernetes RBAC configuration.",
       "properties": {
-        "super_user": {
-          "description": "Determines the authorization-rbac-super-user flag used to start the apiserver in versions of kubernetes <= 1.5",
-          "type": "string",
-          "default": "placeholder"
-        }
       },
-      "required": [
-      ],
       "type": "object"
     }
   },


### PR DESCRIPTION
I removed the 1.5 super_user property from rbacKubeAuth authz in our config (since we now support minor releases 1.6.x, 1.7.x, and 1.8.x).  Now authz only has an empty rbac property.  This is used in many places to test if RBAC is defined.  I am leaving this in so that RBAC could be turned off, or so we could add additional future properties to RBAC.