### PR TITLE
changes to add a post_provider ansible tag

### DIFF
--- a/Documentation/tags/README.md
+++ b/Documentation/tags/README.md
@@ -103,6 +103,8 @@ fabric_only,services_only
 - roles/kraken.rbac
 - roles/kraken.readiness
 - roles/kraken.fabric/kraken.fabric.selector
+- roles/kraken.readiness
+- roles/kraken.ssh/kraken.ssh.selector
 - roles/kraken.services
 - roles/kraken.post
 
@@ -136,17 +138,30 @@ fabric_only,services_only
 
 
 ### provider
- **: Render and spins up actual kubernetes cluster on cloud such as AWS or GKE.**
+ **: Render and spins up unconfigured kubernetes cluster on cloud such as AWS or GKE.**
 - roles/kraken.config
 - roles/kraken.cluster_common
 - roles/kraken.nodePool/kraken.nodePool.selector
 - roles/kraken.assembler
 - roles/kraken.provider/kraken.provider.selector
+
+### post_provider
+ **: Assumes a set of machines has been created and has nodes in etcd, master and cluster pools**
+ **: Requires manually setting krakenconfig cli variable**
+- roles/kraken.config
+- roles/kraken.cluster_common
+- roles/kraken.access
+- roles/kraken.rbac
+- roles/kraken.readiness
 - roles/kraken.fabric/kraken.fabric.selector
+- roles/kraken.readiness
+- roles/kraken.ssh/kraken.ssh.selector
+- roles/kraken.services
 - roles/kraken.post
 
 ### ssh_only
 **: To regenerate the ssh config without doing other stuff**
+- roles/kraken.readiness
 - roles/kraken.ssh/kraken.ssh.selector
 
 ### ssh

--- a/ansible/roles/kraken.access/tasks/main.yaml
+++ b/ansible/roles/kraken.access/tasks/main.yaml
@@ -1,11 +1,4 @@
 ---
-- name: Fail when kraken_endpoint defined but empty
-  fail:
-    msg: >-
-      Attempting to configure cluster {{ cluster.name }} and stopping because kraken_endpoint is not set.
-  when: (kraken_endpoint is defined) and (kraken_endpoint == '')
-
-
 - include: setup-certs.yaml
   with_items:
     - "{{ kraken_config.clusters }}"

--- a/ansible/roles/kraken.access/tasks/main.yaml
+++ b/ansible/roles/kraken.access/tasks/main.yaml
@@ -1,4 +1,11 @@
 ---
+- name: Fail when kraken_endpoint defined but empty
+  fail:
+    msg: >-
+      Attempting to configure cluster {{ cluster.name }} and stopping because kraken_endpoint is not set.
+  when: (kraken_endpoint is defined) and (kraken_endpoint == '')
+
+
 - include: setup-certs.yaml
   with_items:
     - "{{ kraken_config.clusters }}"

--- a/ansible/roles/kraken.access/tasks/setup-certs.yaml
+++ b/ansible/roles/kraken.access/tasks/setup-certs.yaml
@@ -7,6 +7,12 @@
 - name: Set cluster fact
   set_fact:
     cluster: "{{ a_cluster }}"
+
+- name: Set kraken_endpoint endpoint to kubernetes_endpoint if kubernetes_endpoint is set (CL arg)
+  set_fact:
+    kraken_endpoint: "{{ kubernetes_endpoint }}"
+  when: kubernetes_endpoint != ""
+
 #
 # certificate auth
 #

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -7,7 +7,7 @@
       }
     - {
         role: 'roles/kraken.cluster_common',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun' ]
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.nodePool/kraken.nodePool.selector',
@@ -23,35 +23,35 @@
       }
     - {
         role: 'roles/kraken.access',
-        tags: [ 'readiness', 'services', 'all', 'dryrun', 'access_only' ]
+        tags: [ 'readiness', 'services', 'all', 'dryrun', 'access_only', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.rbac',
-        tags: [ 'readiness', 'services', 'all', 'dryrun', 'rbac_only' ]
+        tags: [ 'readiness', 'services', 'all', 'dryrun', 'rbac_only', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.readiness',
         wait_for_all_hosts: false,
-        tags: [ 'readiness', 'services', 'all' ]
+        tags: [ 'readiness', 'services', 'all', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.fabric/kraken.fabric.selector',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'fabric_only' ]
+        tags: [ 'assembler', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'fabric_only', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.readiness',
         wait_for_all_hosts: true,
-        tags: [ 'readiness', 'services', 'all', 'ssh_only' ]
+        tags: [ 'readiness', 'services', 'all', 'ssh_only', 'post_provider' ]
       }
     - { # Run the SSH config generation when all nodes/ASGs are ready.
         role: 'roles/kraken.ssh/kraken.ssh.selector',
-        tags: [ 'ssh', 'all', 'dryrun' ,'ssh_only' ]
+        tags: [ 'ssh', 'all', 'dryrun' ,'ssh_only', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.services',
-        tags: [ 'services', 'services_only', 'all', 'dns_only' ]
+        tags: [ 'services', 'services_only', 'all', 'dns_only', 'post_provider' ]
       }
     - {
         role: 'roles/kraken.post',
-        tags: [ 'all','provider','readiness','services','post_only' ]
+        tags: [ 'all','readiness','services','post_only', 'post_provider' ]
       }

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -19,11 +19,11 @@
       }
     - {
         role: 'roles/kraken.provider/kraken.provider.selector',
-        tags: [ 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun']
+        tags: [ 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'provider_access']
       }
     - {
         role: 'roles/kraken.access',
-        tags: [ 'readiness', 'services', 'all', 'dryrun', 'access_only', 'post_provider' ]
+        tags: [ 'readiness', 'services', 'all', 'dryrun', 'access_only', 'post_provider' , 'provider_access']
       }
     - {
         role: 'roles/kraken.rbac',

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -18,7 +18,7 @@ KRAKEN_HELP=false
 UPDATE_NODEPOOLS=''
 ADD_NODEPOOLS=''
 REMOVE_NODEPOOLS=''
-KRAKEN_ENDPOINT=''
+K8S_ENDPOINT=''
 
 # set RANDFILE to prevent creation of ${HOME}/.rnd by openssl
 export RANDFILE=$(mktemp)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -18,6 +18,7 @@ KRAKEN_HELP=false
 UPDATE_NODEPOOLS=''
 ADD_NODEPOOLS=''
 REMOVE_NODEPOOLS=''
+KRAKEN_ENDPOINT=''
 
 # set RANDFILE to prevent creation of ${HOME}/.rnd by openssl
 export RANDFILE=$(mktemp)

--- a/lib/kraken_arguments.sh
+++ b/lib/kraken_arguments.sh
@@ -47,6 +47,10 @@ case $key in
   KRAKEN_TAGS="$2"
   shift
   ;;
+  -k|--krakenendpoint)
+  KRAKEN_ENDPOINT="$2"
+  shift
+  ;;
   -v|--verbose)
   K2_VERBOSE="$2"
   shift
@@ -106,6 +110,7 @@ KRAKEN_EXTRA_VARS="config_path=${KRAKEN_CONFIG} config_base=${KRAKEN_BASE} \
                    add_nodepools=${ADD_NODEPOOLS} \
                    remove_nodepools=${REMOVE_NODEPOOLS} \
                    dns_only=${DNS_ONLY} \
+                   kraken_endpoint=${KRAKEN_ENDPOINT} \
                   "
 
 if [ ! -z ${BUILD_TAG+x} ]; then

--- a/lib/kraken_arguments.sh
+++ b/lib/kraken_arguments.sh
@@ -104,6 +104,10 @@ else
     DNS_ONLY=false
 fi
 
+if [[ ${KRAKEN_DRYRUN} == true && -z ${KRAKEN_ENDPOINT} ]]; then
+    KRAKEN_ENDPOINT="dryrun"
+fi
+
 KRAKEN_EXTRA_VARS="config_path=${KRAKEN_CONFIG} config_base=${KRAKEN_BASE} \
                    config_forced=${KRAKEN_FORCE} dryrun=${KRAKEN_DRYRUN} \
                    update_nodepools=${UPDATE_NODEPOOLS} \

--- a/lib/kraken_arguments.sh
+++ b/lib/kraken_arguments.sh
@@ -47,8 +47,8 @@ case $key in
   KRAKEN_TAGS="$2"
   shift
   ;;
-  -k|--krakenendpoint)
-  KRAKEN_ENDPOINT="$2"
+  -k|--kubernetesendpoint)
+  K8S_ENDPOINT="$2"
   shift
   ;;
   -v|--verbose)
@@ -104,17 +104,13 @@ else
     DNS_ONLY=false
 fi
 
-if [[ ${KRAKEN_DRYRUN} == true && -z ${KRAKEN_ENDPOINT} ]]; then
-    KRAKEN_ENDPOINT="dryrun"
-fi
-
 KRAKEN_EXTRA_VARS="config_path=${KRAKEN_CONFIG} config_base=${KRAKEN_BASE} \
                    config_forced=${KRAKEN_FORCE} dryrun=${KRAKEN_DRYRUN} \
                    update_nodepools=${UPDATE_NODEPOOLS} \
                    add_nodepools=${ADD_NODEPOOLS} \
                    remove_nodepools=${REMOVE_NODEPOOLS} \
                    dns_only=${DNS_ONLY} \
-                   kraken_endpoint=${KRAKEN_ENDPOINT} \
+                   kubernetes_endpoint=${K8S_ENDPOINT} \
                   "
 
 if [ ! -z ${BUILD_TAG+x} ]; then


### PR DESCRIPTION
the post_provider ansible tag runs all roles necessary to complete
the configuration of a cluster after it has been provisioned using
cloud-config files generated by kraken.  this is useful when
manually creating the nodes in a new cloud provider and using
kraken for everything else.

this is part of #939