### PR TITLE
admission control and runtime config flags now exposed

### DIFF
--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
@@ -27,7 +27,7 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
-{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.admissionControl is defined %}
+{% if node.apiServerConfig.flags is defined and node.apiServerConfig.flags.admissionControl is defined %}
         - --admission-control={{ node.apiServerConfig.admissionControl }}
 {% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
@@ -41,7 +41,7 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
-{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.runtimeConfig is defined %}
+{% if node.apiServerConfig.flags is defined and node.apiServerConfig.flags.runtimeConfig is defined %}
         - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
 {% else %}
         - --runtime-config=batch/v2alpha1=true

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
@@ -27,7 +27,11 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
+{% if node.apiServerConfig.flags.admissionControl is defined %}
+        - --admission-control={{ node.apiServerConfig.admissionControl }}
+{% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
+{% endif %}
         - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
         - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -37,7 +41,14 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
+{% if node.apiServerConfig.flags.runtimeConfig is defined %}
+        - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
+{% else %}
         - --runtime-config=batch/v2alpha1=true
+{% endif %}
+{% if node.apiServerConfig.flags.admissionControlConfigFile is defined %}
+        - --admission-control-config-file={{ node.apiServerConfig.admissionControlConfigFile }}
+{% endif %}
 {% if cluster.kubeAuth.authn.oidc is defined %}
         - --oidc-issuer-url={{cluster.kubeAuth.authn.oidc.issuer}}
         - --oidc-client-id=example-app

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
@@ -27,7 +27,7 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
-{% if node.apiServerConfig.flags.admissionControl is defined %}
+{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.admissionControl is defined %}
         - --admission-control={{ node.apiServerConfig.admissionControl }}
 {% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
@@ -41,12 +41,12 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
-{% if node.apiServerConfig.flags.runtimeConfig is defined %}
+{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.runtimeConfig is defined %}
         - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
 {% else %}
         - --runtime-config=batch/v2alpha1=true
 {% endif %}
-{% if node.apiServerConfig.flags.admissionControlConfigFile is defined %}
+{% if node.apiServerConfig.flags is defined and node.apiServerConfig.flags.admissionControlConfigFile is defined %}
         - --admission-control-config-file={{ node.apiServerConfig.admissionControlConfigFile }}
 {% endif %}
 {% if cluster.kubeAuth.authn.oidc is defined %}

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -27,7 +27,7 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
-{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.admissionControl is defined %}
+{% if node.apiServerConfig.flags is defined and node.apiServerConfig.flags.admissionControl is defined %}
         - --admission-control={{ node.apiServerConfig.admissionControl }}
 {% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
@@ -42,7 +42,7 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
-{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.runtimeConfig is defined %}
+{% if node.apiServerConfig.flags is defined and node.apiServerConfig.flags.runtimeConfig is defined %}
         - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
 {% else %}
         - --runtime-config=batch/v2alpha1=true

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -27,7 +27,12 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
+{% if node.apiServerConfig.flags.admissionControl is defined %}
+        - --admission-control={{ node.apiServerConfig.admissionControl }}
+{% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
+{% endif %}
+
         - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
         - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
         - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -37,7 +42,11 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
+{% if node.apiServerConfig.flags.runtimeConfig is defined %}
+        - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
+{% else %}
         - --runtime-config=batch/v2alpha1=true
+{% endif %}
 {% if cluster.kubeAuth.authn.oidc is defined %}
         - --oidc-issuer-url={{cluster.kubeAuth.authn.oidc.issuer}}
         - --oidc-client-id=example-app

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -27,7 +27,7 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
-{% node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.admissionControl is defined %}
+{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.admissionControl is defined %}
         - --admission-control={{ node.apiServerConfig.admissionControl }}
 {% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
@@ -42,7 +42,7 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
-{% node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.runtimeConfig is defined %}
+{% if node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.runtimeConfig is defined %}
         - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
 {% else %}
         - --runtime-config=batch/v2alpha1=true

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/api-server-manifest.yaml.jinja2
@@ -27,7 +27,7 @@
         - --allow-privileged=true
         - --service-cluster-ip-range={{ cluster.network }}
         - --secure-port=443
-{% if node.apiServerConfig.flags.admissionControl is defined %}
+{% node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.admissionControl is defined %}
         - --admission-control={{ node.apiServerConfig.admissionControl }}
 {% else %}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
@@ -42,7 +42,7 @@
         - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
         - --cloud-provider={{cluster.providerConfig.provider}}
         - --logtostderr=true
-{% if node.apiServerConfig.flags.runtimeConfig is defined %}
+{% node.apiServerConfig.flags is defined and if node.apiServerConfig.flags.runtimeConfig is defined %}
         - --runtime-config={{ node.apiServerConfig.runtimeConfig }}
 {% else %}
         - --runtime-config=batch/v2alpha1=true

--- a/schemas/config/v1/apiServerConfig.json
+++ b/schemas/config/v1/apiServerConfig.json
@@ -3,7 +3,7 @@
   "id": "http://judkins.house/apis/k2/v1/apiServerConfig.json",
   "$$target": "apiServerConfig.json",
   "title": "Kubernetes API server configuration",
-  "description": "kvStore (e.g. etcd) for API servers",
+  "description": "API Server properties such as the state kvStore (e.g. etcd) or flags",
 
   "properties": {
     "name": {

--- a/schemas/config/v1/apiServerConfig.json
+++ b/schemas/config/v1/apiServerConfig.json
@@ -29,6 +29,10 @@
     },
     "events": {
       "etcd": { "$ref": "kvStoreConfig.json" }
+    },
+    "flags": {
+      "description": "Flags that we allow to change for a kraken cluster",
+      "$ref": "apiServerFlags.json"
     }
   },
   "required": [

--- a/schemas/config/v1/apiServerFlags.json
+++ b/schemas/config/v1/apiServerFlags.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/apiServerConfigFlags.json",
+  "$$target": "apiServerConfigFlags.json",
+  "title": "Kubernetes API server flags",
+  "description": "modifiable flags for apiserver",
+
+  "properties": {
+    "admissionControl": {
+      "description": "Comma separated list of admission-controls to use in cluster",
+      "type": "string"
+    },
+    "runtimeConfig": {
+      "description": "Comma separated list of runtime configs to use in cluster",
+      "type": "string"
+    },
+    "admissionControlConfigFile": {
+      "description": "Comma separated list of runtime configs to use in cluster",
+      "type": "string"
+    }
+  },
+  "required": [],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/apiServerFlags.json
+++ b/schemas/config/v1/apiServerFlags.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://judkins.house/apis/k2/v1/apiServerConfigFlags.json",
-  "$$target": "apiServerConfigFlags.json",
+  "id": "http://judkins.house/apis/k2/v1/apiServerFlags.json",
+  "$$target": "apiServerFlags.json",
   "title": "Kubernetes API server flags",
   "description": "modifiable flags for apiserver",
 


### PR DESCRIPTION
Allows for them  to be changed them with our own, for example:

```
 apiServerConfigs:
    - &defaultApiServer
      name: defaultApiServer
      kind: apiServer
      loadBalancer: cloud
      state:
        etcd: *defaultEtcd
      events:
        etcd: *defaultEtcdEvents
      flags:
        admissionControl: "NamespaceLifecycle,LimitRanger,ServiceAccount,NodeRestriction,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,Initializers"
        runtimeConfig: "batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true"
```

allows us to now run istio with automatic injection. A configmap may be required in future work.