### PR TITLE
default cluster auto-scaling enabled for GKE clusters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ podTemplate(label: 'kraken-lib', containers: [
     secretVolume(mountPath: '/home/jenkins/.docker/', secretName: 'samsung-cnct-quay-robot-dockercfg')
   ]) {
     node('kraken-lib') {
+        envVar(key: 'CLOUDSDK_CORE_PROJECT', value: 'k8s-work')
         customContainer('kraken-tools'){
 
             stage('Checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,6 @@ podTemplate(label: 'kraken-lib', containers: [
     secretVolume(mountPath: '/home/jenkins/.docker/', secretName: 'samsung-cnct-quay-robot-dockercfg')
   ]) {
     node('kraken-lib') {
-        envVar(key: 'CLOUDSDK_CORE_PROJECT', value: 'k8s-work')
         customContainer('kraken-tools'){
 
             stage('Checkout') {

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -133,9 +133,9 @@ definitions:
       type: distro
   autoScalingConfigs:
     - &defaultAutoScaling
-      minNodes: 1
+      minNodes: 3
       maxNodes: 10
-      enabled: true
+      enabled: false
   nodeConfigs:
     - &defaultGKEClusterNode
       name: defaultGKEClusterNode

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -131,6 +131,11 @@ definitions:
       kind: container
       runtime: docker
       type: distro
+  autoScalingConfigs:
+    - &defaultAutoScaling
+      minNodes: 1
+      maxNodes: 10
+      enabled: true
   nodeConfigs:
     - &defaultGKEClusterNode
       name: defaultGKEClusterNode
@@ -211,10 +216,12 @@ deployment:
           count: 2
           kubeConfig: *defaultKube
           nodeConfig: *defaultGKEClusterNode
+          autoScalingConfig: *defaultAutoScaling
         - name: othernodes
           count: 2
           kubeConfig: *defaultKube
           nodeConfig: *defaultGKEOtherNode
+          autoScalingConfig: *defaultAutoScaling
       fabricConfig: *kubeVersionedFabric
       helmConfig: *defaultHelm
       dnsConfig: *defaultDns

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
@@ -47,6 +47,7 @@
       --max-nodes={{ item.autoScalingConfig.maxNodes }} 
       --node-pool={{ item.name }}
       --zone {{ cluster.providerConfig.zone.primaryZone }}
+      --project 'k8s-work'
   with_items:
     - "{{ cluster.nodePools }}"
   when:

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
@@ -40,4 +40,17 @@
     KUBECONFIG: "{{ config_base }}/{{ cluster.name }}/admin.kubeconfig"
     CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE: True
 
+- name: Enable autoscaling
+  command: >
+    gcloud --quiet beta container clusters update {{ cluster.name }} --enable-autoscaling 
+      --min-nodes={{ item.autoScalingConfig.minNodes }} 
+      --max-nodes={{ item.autoScalingConfig.maxNodes }} 
+      --node-pool={{ item.name }}
+      --zone {{ cluster.providerConfig.zone.primaryZone }}
+  with_items:
+    - "{{ cluster.nodePools }}"
+  when:
+    - item.autoScalingConfig is defined
+    - item.autoScalingConfig.enabled == true
+
 - include: update-cluster.yaml

--- a/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.gke/tasks/create-cluster.yaml
@@ -47,7 +47,7 @@
       --max-nodes={{ item.autoScalingConfig.maxNodes }} 
       --node-pool={{ item.name }}
       --zone {{ cluster.providerConfig.zone.primaryZone }}
-      --project 'k8s-work'
+      --project {{ cluster.providerConfig.project }}
   with_items:
     - "{{ cluster.nodePools }}"
   when:

--- a/ansible/roles/kraken.services/tasks/run-services.yaml
+++ b/ansible/roles/kraken.services/tasks/run-services.yaml
@@ -220,3 +220,4 @@
   when:
     - item.autoScalingConfig is defined
     - item.autoScalingConfig.enabled
+    - cluster.providerConfig.provider == 'aws'


### PR DESCRIPTION
Fixes: https://github.com/samsung-cnct/kraken-lib/issues/150
Related to: https://github.com/samsung-cnct/kraken-lib/pull/948

Enables cluster-autoscaling in GKE clusters.

NOTES: 
- There is not a Helm chart for GKE cluster auto-scaling. 
- The `--quiet` flag is in a unconventional location, but it does not work listed after the command on a new line.
