### PR TITLE
Implement etcd monitoring by creating an internal loadbalancer to

### DIFF
--- a/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/tasks/each-cluster-nodepool.yaml
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/tasks/each-cluster-nodepool.yaml
@@ -46,3 +46,4 @@
   with_items:
     - etcd.units.etcd.part.jinja2
     - etcd.units.kraken-etcd-ssl.part.jinja2
+    - etcd.units.kraken-fluent-bit.part.jinja2

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/etcd.units.kraken-fluent-bit.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.etcd/templates/etcd.units.kraken-fluent-bit.part.jinja2
@@ -1,0 +1,23 @@
+- name: kraken-fluent-bit.service
+  runtime: true
+  command: start
+  content: |
+    [Unit]
+    Description=Kraken fluent-bit monitoring for non-kubernetes nodes (e.g. etcd)
+    After=kraken-networking.service
+    Requires=kraken-networking.service
+    [Service]
+    TimeoutStartSec=0
+    RestartSec=15
+    Restart=always
+    KillMode=none
+    ExecStart=/usr/bin/rkt run --net=host \
+     --stage1-path=/usr/lib/rkt/stage1-images/stage1-fly.aci \
+     --insecure-options=image \
+     --inherit-env=true \
+     --volume resolv-conf,kind=host,source=/etc/resolv.conf \
+     --mount volume=resolv-conf,target=/etc/resolv.conf \
+     --set-env=FLUENT_ELASTICSEARCH_HOST=apiserver.{{ cluster_node_tuple.0.name }}.internal \
+     --set-env=FLUENT_ELASTICSEARCH_PORT=9200 \
+     quay.io/samsung_cnct/fluent-bit-container:latest
+    ExecStopPost=/usr/bin/rkt gc --mark-only

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -192,12 +192,55 @@ resource "aws_elb" "master_elb" {
   }
 }
 
+resource "aws_elb" "master_internal_elb" {
+  name = "${var.master_name}-master-internal-elb"
+
+  internal = true
+
+  cross_zone_load_balancing = true
+
+  {% if master.apiServerConfig.loadBalancerConfigs is defined %}
+  subnets = [{% set comma = joiner(",") %}{% for subnet in master.apiServerConfig.loadBalancerConfigs.subnet %}{{ comma() }}"${var.{{subnet}}_subnet_id}"{% endfor %}]
+  {% else %}
+  subnets = [{% set comma = joiner(",") %}{% for subnet in master.nodeConfig.providerConfig.subnet %}{{ comma() }}"${var.{{subnet}}_subnet_id}"{% endfor %}]
+  {% endif %}
+
+  security_groups = ["${var.kubernetes_sec_group}"]
+
+  listener {
+    instance_port = 443
+    instance_protocol = "tcp"
+    lb_port = 443
+    lb_protocol = "tcp"
+  }
+
+  listener {
+    instance_port = 30920
+    instance_protocol = "tcp"
+    lb_port = 30920
+    lb_protocol = "tcp"
+  }
+
+  health_check {
+    healthy_threshold = 2
+    unhealthy_threshold = 10
+    timeout = 2
+    target = "TCP:443"
+    interval = 5
+  }
+
+  tags {
+    Name = "${var.master_name}_master_internel_elb",
+    KubernetesCluster = "${var.master_name}"
+  }
+}
+
 resource "aws_route53_record" "master_record" {
   zone_id = "${var.route53_zone_id}"
   name = "apiserver.${var.master_name}.internal"
   type = "CNAME"
   ttl = "300"
-  records = ["${aws_elb.master_elb.dns_name}"]
+  records = ["${aws_elb.master_internal_elb.dns_name}"]
 }
 
 {% if cluster.kubeAuth.authn.oidc is defined %}
@@ -287,7 +330,7 @@ resource "aws_autoscaling_group" "master_nodes" {
   desired_capacity          = "{{master.count}}"
   {%- if master.apiServerConfig.loadBalancer == 'cloud'  %}
   wait_for_elb_capacity     =  "{{master.count}}"
-  load_balancers            = ["${aws_elb.master_elb.name}"]
+  load_balancers            = ["${aws_elb.master_elb.name}", "${aws_elb.master_internal_elb.name}"]
   health_check_type         = "ELB"
   {%- else %}
   health_check_type         = "EC2"


### PR DESCRIPTION
the apiservers and pointing fluent-bit at it (fixes #825). Note
that this change makes the apiserver.{{ cluster.name }}.internal
CNAME to point to the internal ELB and therefore internal IP
addresses (as the name suggests!).