### PR TITLE
add a default for kubernetes_endpoint in the playbook

### DIFF
--- a/ansible/roles/kraken.access/defaults/main.yaml
+++ b/ansible/roles/kraken.access/defaults/main.yaml
@@ -1,1 +1,2 @@
 ---
+kubernetes_endpoint: ""


### PR DESCRIPTION
kraken calls the playbook directly so it skips the defaulting that
happens in the shell scripts