### PR TITLE
Updated versions for weave, flannel, and calico

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -41,7 +41,7 @@ definitions:
             version: v2.6.1
             location: quay.io/calico/node
           flannel:
-            version: v0.8.0
+            version: v0.9.1
             location: quay.io/coreos/flannel
         network:
           network: 10.128.0.0/10
@@ -60,10 +60,10 @@ definitions:
             version: v1.10.0
             location: quay.io/calico/cni
           calicoNode:
-            version: v2.4.1
+            version: v2.6.1
             location: quay.io/calico/node
           flannel:
-            version: v0.8.0
+            version: v0.9.1
             location: quay.io/coreos/flannel
         network:
           network: 10.128.0.0/10
@@ -87,10 +87,10 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.8
+            version: 2.1.1
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.8
+            version: 2.1.1
             location: weaveworks/weave-npc
         network:
           network: 10.128.0.0/10

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -60,10 +60,10 @@ definitions:
             version: v1.10.0
             location: quay.io/calico/cni
           calicoNode:
-            version: v2.6.2
+            version: v2.4.1
             location: quay.io/calico/node
           flannel:
-            version: v0.9.1
+            version: v0.8.0
             location: quay.io/coreos/flannel
         network:
           network: 10.128.0.0/10

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -38,7 +38,7 @@ definitions:
             version: v1.10.0
             location: quay.io/calico/cni
           calicoNode:
-            version: v2.6.1
+            version: v2.6.2
             location: quay.io/calico/node
           flannel:
             version: v0.9.1
@@ -60,7 +60,7 @@ definitions:
             version: v1.10.0
             location: quay.io/calico/cni
           calicoNode:
-            version: v2.6.1
+            version: v2.6.2
             location: quay.io/calico/node
           flannel:
             version: v0.9.1

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -28,19 +28,19 @@ definitions:
       options:
         containers:
           kubePolicyController:
-            version: v0.5.1
+            version: v1.0.0-rc4
             location: calico/kube-policy-controller
           etcd:
             version: v3.0.9
             location: quay.io/coreos/etcd
           calicoCni:
-            version: v1.4.2
+            version: v1.10.0
             location: calico/cni
           calicoNode:
-            version: v1.0.0-rc1
+            version: v2.6.2
             location: quay.io/calico/node
           flannel:
-            version: v0.6.1
+            version: v0.9.1
             location: quay.io/coreos/flannel
         network:
           network: 10.128.0.0/10
@@ -59,10 +59,10 @@ definitions:
             version: v1.10.0
             location: quay.io/calico/cni
           calicoNode:
-            version: v2.4.1
+            version: v2.6.2
             location: quay.io/calico/node
           flannel:
-            version: v0.8.0
+            version: v0.9.1
             location: quay.io/coreos/flannel
         network:
           network: 10.128.0.0/10
@@ -87,10 +87,10 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.8
+            version: 2.1.1
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.8
+            version: 2.1.1
             location: weaveworks/weave-npc
         network:
           network: 10.128.0.0/10
@@ -102,10 +102,10 @@ definitions:
       options:
         containers:
           weave:
-            version: 1.9.8
+            version: 2.1.1
             location: weaveworks/weave-kube
           weave_npc:
-            version: 1.9.8
+            version: 2.1.1
             location: weaveworks/weave-npc
         network:
           network: 10.128.0.0/10

--- a/ansible/roles/kraken.config/files/gke-config.yaml
+++ b/ansible/roles/kraken.config/files/gke-config.yaml
@@ -59,10 +59,10 @@ definitions:
             version: v1.10.0
             location: quay.io/calico/cni
           calicoNode:
-            version: v2.6.2
+            version: v2.4.1
             location: quay.io/calico/node
           flannel:
-            version: v0.9.1
+            version: v0.8.0
             location: quay.io/coreos/flannel
         network:
           network: 10.128.0.0/10
@@ -102,10 +102,10 @@ definitions:
       options:
         containers:
           weave:
-            version: 2.1.1
+            version: 1.9.8
             location: weaveworks/weave-kube
           weave_npc:
-            version: 2.1.1
+            version: 1.9.8
             location: weaveworks/weave-npc
         network:
           network: 10.128.0.0/10


### PR DESCRIPTION
Did a quick cluster up and get pods for both aws and gke.  Will let CI do the rest