### PR TITLE
Use m4.large for clusterNodes and c4.large for specialNodes. This

### DIFF
--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -246,7 +246,7 @@ definitions:
       providerConfig:
         enablePublicIPs: true
         provider: aws
-        type: c4.large
+        type: m4.large
         subnet: ["zone-1", "zone-2", "zone-3"]
         tags:
           -
@@ -274,7 +274,7 @@ definitions:
       providerConfig:
         provider: aws
         enablePublicIPs: true
-        type: m4.large
+        type: c4.large
         subnet: ["zone-1", "zone-2", "zone-3"]
         tags:
           -


### PR DESCRIPTION
allows us to deploy logging by default while still testing two
nodepools composed of two different instance types.