### PR TITLE
Pre provider

### DIFF
--- a/Documentation/tags/README.md
+++ b/Documentation/tags/README.md
@@ -133,7 +133,8 @@ fabric_only,services_only
 - roles/kraken.fabric/kraken.fabric.selector
 
 ### fabric_only
- **: Render and execute kubernetes config yamls for creating the nework fabric.** Useful for development and production upgrades of a network **
+ **: Render and execute kubernetes config yamls for creating the nework fabric.**
+ **: Useful for development and production upgrades of a network**
 - roles/kraken.fabric/kraken.fabric.selector
 
 
@@ -144,6 +145,13 @@ fabric_only,services_only
 - roles/kraken.nodePool/kraken.nodePool.selector
 - roles/kraken.assembler
 - roles/kraken.provider/kraken.provider.selector
+
+### pre_provider
+ **: create cloud-config files**
+- roles/kraken.config
+- roles/kraken.cluster_common
+- roles/kraken.nodePool
+- roles/kraken.assembler
 
 ### post_provider
  **: Assumes a set of machines has been created and has nodes in etcd, master and cluster pools**

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -7,15 +7,15 @@
       }
     - {
         role: 'roles/kraken.cluster_common',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider' ]
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider', 'pre_provider' ]
       }
     - {
         role: 'roles/kraken.nodePool/kraken.nodePool.selector',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun' ]
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'pre_provider' ]
       }
     - {
         role: 'roles/kraken.assembler',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun' ]
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'pre_provider' ]
       }
     - {
         role: 'roles/kraken.provider/kraken.provider.selector',


### PR DESCRIPTION
adds a new tag to kraken-lib 'pre_provider' that runs all roles before the provider selector.  This is useful for creating the cloud-config artifacts and stopping.  possibly only useful as a development tool.