### PR TITLE
Fix e2e failure on udp communication from node to pod

### DIFF
--- a/ansible/library/compatibility.py
+++ b/ansible/library/compatibility.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCUMENTATION = '''  
+DOCUMENTATION = '''
 ---
 module: compatibility
 short_description: Verifies whether a given kraken config file contains any
@@ -179,5 +179,5 @@ def main():
         msg = "The kraken config appears to be compatible."
     module.exit_json(changed=False, msg=msg, **result)
 
-if __name__ == '__main__':  
+if __name__ == '__main__':
     main()

--- a/ansible/roles/kraken.config/files/config.yaml
+++ b/ansible/roles/kraken.config/files/config.yaml
@@ -156,7 +156,7 @@ definitions:
       name: defaultCoreOs
       kind: os
       type: coreOs
-      version: 1520.8.0
+      version: 1520.9.0
       channel: stable
       # If rebootStrategy is anything other than "off" then the version of
       # CoreOS specified above will not be pinned.


### PR DESCRIPTION
A kernel bug introduced somewhere in the coreos 1520 releases prevents udp communication from a node to a pod due to a bad checksum (which is expected) being checked for validation (which is unexpected) on a veth interface. CoreOs release 1520.9.0 does not exhibit this failure.