### PR TITLE
Create a backup of Kraken configs

### DIFF
--- a/ansible/roles/kraken.config/tasks/main.yaml
+++ b/ansible/roles/kraken.config/tasks/main.yaml
@@ -31,6 +31,25 @@
 - name: Validate the config against the schema
   include: validate-config.yaml
 
+- name: Ensure cluster directories exist
+  file:
+    path: "{{ config_base }}/{{ cluster.name }}/"
+    state: directory
+  with_items:
+    - "{{ kraken_config.clusters }}"
+  loop_control:
+    loop_var: cluster
+
+- name: Backup the configuration file
+  copy:
+    src: "{{ config_file }}"
+    dest: "{{ config_base }}/{{ cluster.name }}/{{ config_file | basename }}"
+    backup: yes
+  with_items:
+    - "{{ kraken_config.clusters }}"
+  loop_control:
+    loop_var: cluster
+
 - name: Verify and set global facts
   include: global-setup.yaml
 


### PR DESCRIPTION
This will make backup of kraken config file in cluster directory when the config file is changed.

```
june@hp650:~/.kraken/june$ ls -al
total 60
drwxrwxr-x 3 june june 4096 Dec 12 10:43 .
drwxrwxr-x 3 june june 4096 Dec 12 10:43 ..
-rw------- 1 june june 5642 Dec 12 10:17 admin.kubeconfig
-rw-r--r-- 1 june june   61 Dec 12 10:43 cluster.status.lock
-rw-rw-r-- 1 june june 6254 Dec 12 10:43 config.yaml
-rw-rw-r-- 1 june june 6254 Dec 12 10:34 config.yaml.21932.2017-12-12@10:37:31~
-rw-rw-r-- 1 june june 6253 Dec 12 10:37 config.yaml.23572.2017-12-12@10:40:01~
-rw-rw-r-- 1 june june 6257 Dec 12 10:40 config.yaml.26739.2017-12-12@10:43:11~
-rw-rw-r-- 1 june june 1767 Dec 12 10:13 deploymentmanager-create.yaml
drwxrwxr-x 5 june june 4096 Dec 12 10:17 .helm
-rw-rw-r-- 1 june june    0 Dec 12 10:17 ssh_config
```