### PR TITLE
Add certified kubernetes badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/samsung_cnct/k2/status "Docker Repository on Quay")](https://quay.io/repository/samsung_cnct/k2)
 
+<a href="https://github.com/cncf/k8s-conformance/tree/master/v1.8/kraken"><img src="https://raw.githubusercontent.com/cncf/artwork/master/kubernetes/certified-kubernetes/1.8/color/certified_kubernetes_1.8_color.png" width="80" align="right"></a>
+<a href="https://github.com/cncf/k8s-conformance/tree/master/v1.7/kraken"><img src="https://raw.githubusercontent.com/cncf/artwork/master/kubernetes/certified-kubernetes/1.7/color/certified_kubernetes_1.7_color.png" width="80" align="right"></a>
+
 Please use [kraken](https://github.com/samsung-cnct/k2cli), the intended user interface to kraken-lib. The
 following instructions are intended for developers working on kraken-lib.
 


### PR DESCRIPTION
We're mentioned as certified here: https://www.cncf.io/announcement/2017/11/13/cloud-native-computing-foundation-launches-certified-kubernetes-program-32-conformant-distributions-platforms/

Add the badges we have earned, and link to the instructions people can use to reproduce the conformance results on their own with kraken

ref: samsung-cnct/kraken#223