### PR TITLE
Ubuntu hack

### DIFF
--- a/Documentation/tags/README.md
+++ b/Documentation/tags/README.md
@@ -133,7 +133,11 @@ fabric_only,services_only
 - roles/kraken.fabric/kraken.fabric.selector
 
 ### fabric_only
+<<<<<<< 8129546e82d958cfa64849ca3942a7558dc5df6b
  **: Render and execute kubernetes config yamls for creating the network fabric**
+=======
+ **: Render and execute kubernetes config yamls for creating the nework fabric.**
+>>>>>>> add docs for pre_provider tag
  **: Useful for development and production upgrades of a network**
 - roles/kraken.fabric/kraken.fabric.selector
 

--- a/Documentation/tags/README.md
+++ b/Documentation/tags/README.md
@@ -133,11 +133,7 @@ fabric_only,services_only
 - roles/kraken.fabric/kraken.fabric.selector
 
 ### fabric_only
-<<<<<<< 8129546e82d958cfa64849ca3942a7558dc5df6b
  **: Render and execute kubernetes config yamls for creating the network fabric**
-=======
- **: Render and execute kubernetes config yamls for creating the nework fabric.**
->>>>>>> add docs for pre_provider tag
  **: Useful for development and production upgrades of a network**
 - roles/kraken.fabric/kraken.fabric.selector
 

--- a/ansible/roles/kraken.config/tasks/per-cluster-setup.yaml
+++ b/ansible/roles/kraken.config/tasks/per-cluster-setup.yaml
@@ -42,7 +42,7 @@
     msg: |
       {{ cluster.providerConfig.provider }} is not a supported cloud provider. Please file an issue at
       https://github.com/samsung-cnct/k2/issues to request support.
-  when: cluster.providerConfig.provider not in ['aws', 'gke']
+  when: cluster.providerConfig.provider not in ['aws', 'gke', 'maas']
 
 - name: Verify kubeAuth is defined
   fail:

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/tasks/each-cluster-nodepool.yaml
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/tasks/each-cluster-nodepool.yaml
@@ -15,6 +15,7 @@
     - controller-manager-manifest.yaml.jinja2
     - kube-proxy-manifest.yaml.jinja2
     - scheduler-manifest.yaml.jinja2
+    - default-docker.jinja2
 
 - name: Create cloud_config basic auth write_files for master nodes
   include: cloud_config/write_files.yaml

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/api-server-manifest.yaml.jinja2
@@ -95,7 +95,7 @@
           path: /etc/etcd/ssl
         name: ssl-certs-etcd
       - hostPath:
-          path: /usr/share/ca-certificates
+          path: /usr/share/ca-certificates/mozilla
         name: ssl-certs-host
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/controller-manager-manifest.yaml.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/controller-manager-manifest.yaml.jinja2
@@ -49,7 +49,7 @@
           path: /etc/ssl
         name: ssl-certs-ssl
       - hostPath:
-          path: /usr/share/ca-certificates
+          path: /usr/share/ca-certificates/mozilla
         name: ssl-certs-host
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/default-docker.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/default-docker.jinja2
@@ -1,0 +1,5 @@
+- path: /etc/default/docker
+  owner: root
+  permissions: 0644
+  content: |
+    DOCKER_OPTS="--storage-driver=devicemapper"

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -17,7 +17,7 @@
       --volume etc-resolv-conf,kind=host,source=/etc/resolv.conf \
       --volume etc-cni,kind=host,source=/etc/cni \
       --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-      --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
+      --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates/mozilla \
       --volume var-lib-docker,kind=host,source=/var/lib/docker \
       --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
       --volume os-release,kind=host,source=/usr/lib/os-release \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/tasks/each-cluster-nodepool.yaml
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/tasks/each-cluster-nodepool.yaml
@@ -11,6 +11,7 @@
     - kube-proxy-manifest.yaml.jinja2
     - kubeconfig.jinja2
     - proxy-kubeconfig.jinja2
+    - default-docker.jinja2
 
 - name: Create cloud_config units for worker nodes
   include: cloud_config/units.yaml

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/default-docker.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/default-docker.jinja2
@@ -1,0 +1,5 @@
+- path: /etc/default/docker
+  owner: root
+  permissions: 0644
+  content: |
+    DOCKER_OPTS="--storage-driver=devicemapper"

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.node/templates/units.kubelet.part.jinja2
@@ -18,7 +18,7 @@
       --volume etc-resolv-conf,kind=host,source=/etc/resolv.conf \
       --volume etc-cni,kind=host,source=/etc/cni \
       --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-      --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
+      --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates/mozilla \
       --volume var-lib-docker,kind=host,source=/var/lib/docker \
       --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
       --volume var-log,kind=host,source=/var/log \

--- a/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/tasks/main.yaml
@@ -69,6 +69,7 @@
     - not etcd_status_lock_file.stat.exists
     - kraken_action == 'up'
     - not (dryrun | bool)
+    - not distro == 'ubuntu'
 
 - name: Ensure etcd_status_lock file exists
   copy:

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.etcd.tf.jinja2
@@ -84,7 +84,7 @@ resource "coreosbox_ami" "{{node.name}}_ami" {
 {% if node.etcdConfigs is defined %}
 {% for node_idx in range(1, node.count+1)%}
 resource "aws_instance" "{{node.name}}_{{node_idx}}" {
-  ami                         = "${coreosbox_ami.{{node.name}}_ami.box_string}"
+  ami                         = "ami-13c15e69"
   instance_type               = "{{node.nodeConfig.providerConfig.type}}"
   key_name                    = "${var.{{node.keyPair.name}}_{{node.name}}_key}"
   vpc_security_group_ids      = ["${aws_security_group.vpc_etcd_{{node.name}}_secgroup.id}"]

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.master.tf.jinja2
@@ -90,7 +90,7 @@ resource "aws_iam_instance_profile" "kubernetes_master_profile" {
 # Launch configuration for master
 resource "aws_launch_configuration" "master_launch_config" {
   name_prefix                 = "${var.master_name}_master"
-  image_id                    = "${coreosbox_ami.master_ami.box_string}"
+  image_id                    = "ami-13c15e69"
   key_name                    = "${var.master_key_name}"
   instance_type               = "{{master.nodeConfig.providerConfig.type}}"
   security_groups             = ["${var.kubernetes_sec_group}"]

--- a/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
+++ b/ansible/roles/kraken.provider/kraken.provider.aws/templates/kraken.provider.aws.module.node.tf.jinja2
@@ -110,7 +110,7 @@ resource "coreosbox_ami" "{{node.name}}_ami" {
 {% if node.etcdConfigs is not defined and node.apiServerConfig is not defined and node.bastionConfig is not defined %}
 resource "aws_launch_configuration" "{{node.name}}_launch_config" {
   name_prefix                 = "${var.nodes_name}_{{node.name}}"
-  image_id                    = "${coreosbox_ami.{{node.name}}_ami.box_string}"
+  image_id                    = "ami-13c15e69"
   key_name                    = "${var.{{node.keyPair.name}}_{{node.name}}_key}"
   instance_type               = "{{node.nodeConfig.providerConfig.type}}"
   security_groups             = ["${var.kubernetes_sec_group}"]

--- a/ansible/roles/kraken.provider/kraken.provider.selector/tasks/main.yaml
+++ b/ansible/roles/kraken.provider/kraken.provider.selector/tasks/main.yaml
@@ -16,15 +16,3 @@
   loop_control:
     loop_var: a_cluster
   when: a_cluster.providerConfig.provider == 'gke'
-
-- name: Supported Cloud Provider Check
-  include_role:
-    name: '{{ playbook_dir }}/roles/kraken.error'
-    kraken_component_type: provider
-    kraken_component_error: 'Unsupported provider'
-    kraken_component_name: '{{ a_cluster.providerConfig.provider }}'
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: a_cluster.providerConfig.provider not in ['aws', 'gke']

--- a/ansible/roles/kraken.ssh/kraken.ssh.aws/templates/bastion_ssh_config.jinja2
+++ b/ansible/roles/kraken.ssh/kraken.ssh.aws/templates/bastion_ssh_config.jinja2
@@ -4,7 +4,7 @@
 {% if instance.state == 'running' or instance.state == 'pending' %}
 Host {{instance.tags['k2-nodepool']}}-{{validHostCounter}}
   HostName {{instance.private_dns_name}}
-  User core
+  User ubuntu
   Port 22
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null

--- a/ansible/roles/kraken.ssh/kraken.ssh.aws/templates/ssh_config.jinja2
+++ b/ansible/roles/kraken.ssh/kraken.ssh.aws/templates/ssh_config.jinja2
@@ -7,11 +7,11 @@
 {% set privateKeyPath = cluster.nodePools | selectattr("name", "equalto", instance.tags['k2-nodepool']) | list %}
 {% if instance.tags['k2-nodepool'] != 'bastion' and elb_facts is defined and elb_facts.elbs | length >0 %}
 Host {{instance.tags['k2-nodepool']}}-{{validHostCounter}}
-  User core
+  User ubuntu
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
   IdentityFile {{privateKeyPath[0].keyPair.privatekeyFile}}
-  ProxyCommand ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@{{elb_facts.elbs[0].dns_name}} -p {{bastionListenPort}} -W {{instance.private_ip_address}}:22
+  ProxyCommand ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@{{elb_facts.elbs[0].dns_name}} -p {{bastionListenPort}} -W {{instance.private_ip_address}}:22
 {% set validHostCounter = validHostCounter + 1 %}
 {% endif %}
 {% endif %}
@@ -39,7 +39,7 @@ Host {{instance.tags['k2-nodepool']}}-{{validHostCounter}}
 # Public: {{instance.public_dns_name}} {{instance.public_ip_address}}
 Host {{hostAlias}}
   HostName {{publicAddress}}
-  User core
+  User ubuntu
 {% if instance.tags['k2-nodepool'] == 'bastion' %}
   Port {{bastionListenPort}}
 {% else %}

--- a/ansible/roles/kraken.ssh/kraken.ssh.selector/tasks/main.yaml
+++ b/ansible/roles/kraken.ssh/kraken.ssh.selector/tasks/main.yaml
@@ -16,22 +16,3 @@
   loop_control:
     loop_var: a_cluster
   when: a_cluster.providerConfig.provider == 'gke' and not ( dryrun | bool )
-
-- name: Generate shell command help text
-  template:
-    src: help.txt.jinja2
-    dest: "{{ config_base }}/help.txt"
-
-- name: Supported cloud provider check
-  include_role:
-    name: '{{ playbook_dir }}/roles/kraken.error'
-    kraken_component_type: ssh
-    kraken_component_error: 'Unsupported provider'
-    kraken_component_name: '{{ a_cluster.providerConfig.provider }}'
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: a_cluster.providerConfig.provider not in ['aws', 'gke']
-
-

--- a/ansible/roles/kraken.update/kraken.update.selector/tasks/main.yaml
+++ b/ansible/roles/kraken.update/kraken.update.selector/tasks/main.yaml
@@ -17,15 +17,3 @@
   loop_control:
     loop_var: a_cluster
   when: a_cluster.providerConfig.provider == 'gke'
-
-- name: Supported Cloud Provider Check
-  include_role:
-    name: '{{ playbook_dir }}/roles/kraken.error'
-    kraken_component_type: provider
-    kraken_component_error: 'Unsupported provider'
-    kraken_component_name: '{{ a_cluster.providerConfig.provider }}'
-  with_items:
-    - "{{ kraken_config.clusters }}"
-  loop_control:
-    loop_var: a_cluster
-  when: a_cluster.providerConfig.provider not in ['aws', 'gke']

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -7,7 +7,7 @@
       }
     - {
         role: 'roles/kraken.cluster_common',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider', 'pre_provider' ]
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider', 'pre_provider', 'provider_only' ]
       }
     - {
         role: 'roles/kraken.nodePool/kraken.nodePool.selector',
@@ -19,7 +19,7 @@
       }
     - {
         role: 'roles/kraken.provider/kraken.provider.selector',
-        tags: [ 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'provider_access']
+        tags: [ 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'provider_access', 'provider_only']
       }
     - {
         role: 'roles/kraken.access',

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -7,7 +7,7 @@
       }
     - {
         role: 'roles/kraken.cluster_common',
-        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider', 'pre_provider', 'provider_only' ]
+        tags: [ 'assembler', 'provider', 'ssh', 'readiness', 'services', 'all', 'dryrun', 'post_provider', 'pre_provider', 'provider_only', 'access_only']
       }
     - {
         role: 'roles/kraken.nodePool/kraken.nodePool.selector',

--- a/bin/cloudconfigcleanup.py
+++ b/bin/cloudconfigcleanup.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+import re
+
+def clean_start(filepath):
+    cloud_config_fd = open(filepath, "r")
+    cloud_config = cloud_config_fd.read()
+    cloud_config_fd.close()
+
+    return cloud_config
+
+def clean_end(filepath, cloud_config):
+    cloud_config_fd = open(filepath, "w")
+    cloud_config_fd.write(cloud_config)
+    cloud_config_fd.close()
+ 
+def install_docker(cloud_config):
+    late_service_restart = '''runcmd:
+- systemctl restart --no-block docker.service kubelet.service
+'''
+    update_packages = "package_update: true\n"
+    docker_install = "packages:\n- docker.io\n"
+    cloud_config += update_packages
+    cloud_config += docker_install
+    cloud_config += late_service_restart
+    return cloud_config
+
+def fqdn(cloud_config):
+    #  add FQDN environment variable
+    cloud_config = re.sub("EnvironmentFile=/etc/network-environment\\\\n",  \
+        "EnvironmentFile=/etc/network-environment\\\\n\\\\\n    ExecStartPre=/bin/bash -c " + \
+        "'/bin/systemctl set-environment FQDN=`hostname --fqdn`'\\\\n", cloud_config)
+
+    #  use FDQN environment variable
+    cloud_config = re.sub("HOST_NAME=%H", "HOST_NAME=${FQDN}", cloud_config)
+    return cloud_config
+
+
+def clean_etcd(filepath):
+    if filepath is None:
+        print "no filepath passed to script.  do nothing"
+        return
+
+    cloud_config = clean_start(filepath)
+
+    #  rule: change /usr/bin/mkdir to /bin/mkdir
+    cloud_config = re.sub("/usr/bin/mkdir", "/bin/mkdir", cloud_config, count=0)
+
+    #  rule:  change occurances of /usr/bin/[mkdir|bash|systemctl] to /bin/[mkdir|bash|systemctl]
+    cloud_config = re.sub("/usr/bin/([mkdir|bash|systemctl|grep])", "/bin/" + r"\g" + "<1>", \
+        cloud_config)
+    cloud_config = re.sub("/usr/sbin/([blkid|wipefs|mkfs.ext4])", "/sbin/" + r"\g" + "<1>", \
+        cloud_config)
+    cloud_config = re.sub("/bin/([dig])", "/usr/bin/" + r"\g" + "<1>", \
+        cloud_config)
+
+
+    clean_end(filepath, cloud_config)
+    
+def clean_master(filepath, ipaddress):
+    if filepath is None:
+        print "no filepath passed to script.  do nothing"
+        return
+
+    if ipaddress is None:
+        print "ipaddress of etcd not provided.  this is not going to work"
+        return
+
+    cloud_config = clean_start(filepath)
+
+    #  rule:  change occurances of /usr/bin/[mkdir|bash|systemctl] to /bin/[mkdir|bash|systemctl]
+    cloud_config = re.sub("/usr/bin/([mkdir|bash|systemctl|grep])", "/bin/" + r"\g" + "<1>", \
+        cloud_config)
+    cloud_config = re.sub("/usr/sbin/([blkid|wipefs|mkfs.ext4])", "/sbin/" + r"\g" + "<1>", \
+        cloud_config)
+
+    #  rule:  install docker
+    cloud_config = install_docker(cloud_config)
+    
+    #  rule:  need to use the fqdn for ubuntu
+    cloud_config = fqdn(cloud_config)
+
+    clean_end(filepath, cloud_config)
+
+def clean_worker(filepath, ipaddress):
+    if filepath is None:
+        print "no filepath passed to script.  do nothing"
+        return
+
+    if ipaddress is None:
+        print "ipaddress of master not provided.  this is not going to work"
+        return
+
+    cloud_config = clean_start(filepath)
+
+    #  rule:  change occurances of /usr/bin/[mkdir|bash|systemctl] to /bin/[mkdir|bash|systemctl]
+    cloud_config = re.sub("/usr/bin/([mkdir|bash|systemctl|grep])", "/bin/\g<1>", cloud_config)
+    cloud_config = re.sub("/usr/sbin/([blkid|wipefs|mkfs.ext4])", "/sbin/" + r"\g" + "<1>", \
+        cloud_config)
+
+    #  rule:  install docker
+    cloud_config = install_docker(cloud_config)
+
+    #  rule:  need to use the fqdn for ubuntu
+    cloud_config = fqdn(cloud_config)
+
+    clean_end(filepath, cloud_config)

--- a/bin/ssh_command.sh
+++ b/bin/ssh_command.sh
@@ -23,7 +23,7 @@ function show_help {
     inf "[ssh_command].sh -v -f <ssh_config> -n <host> <command>"
 
     inf "\nFor example:"
-    inf "[ssh_command].sh --verbose --address 44.198.159.24 --port 7022  --user core docker pull quay.io/coreos/etcd:latest"
+    inf "[ssh_command].sh --verbose --address 44.198.159.24 --port 7022  --user ubuntu docker pull quay.io/coreos/etcd:latest"
     inf "[ssh_command].sh -v -a 44.198.159.24 -p 7022 -u core -c 'docker pull quay.io/coreos/etcd:latest'"
     inf "[ssh_command].sh --verbose --ssh-config /Users/user/.kraken/cluster/ssh_config --hostname etcd-1 docker pull quay.io/coreos/etcd:latest"
     inf "[ssh_command].sh -v -f /Users/user/.kraken/cluster/ssh_config -n etcd-1 docker pull quay.io/coreos/etcd:latest"

--- a/bin/ubuntu-aws.py
+++ b/bin/ubuntu-aws.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import cloudconfigcleanup
+
+CLOUD_CONFIG_DIR = "/Users/pat/.kraken/pac-ubuntu/cloud-config/"
+
+cloudconfigcleanup.clean_etcd(CLOUD_CONFIG_DIR + "etcd.cloud-config.yaml")
+cloudconfigcleanup.clean_master(CLOUD_CONFIG_DIR + "master.cloud-config.yaml", "fake")
+cloudconfigcleanup.clean_worker(CLOUD_CONFIG_DIR + "clusterNodes.cloud-config.yaml", "fake")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/samsung_cnct/kraken-tools:latest
 
-ARG K2_REPO=https://github.com/samsung-cnct/k2.git
-ARG K2_BRANCH=master
+ARG K2_REPO=https://github.com/joejulian/kraken-lib.git
+ARG K2_BRANCH=support-non-awsgke
 ARG K2_SHA=""
 
 RUN 	apk update && \

--- a/schemas/config/v1/maasAuthenticationConfig.json
+++ b/schemas/config/v1/maasAuthenticationConfig.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasAuthenticationConfig.json",
+  "$$target": "maasAuthenticationConfig.json",
+  "title": "MaaS Security Credentials Configuration",
+  "description": "Describes MaaS security credential configuration.",
+
+  "properties": {
+    "accessKey": {
+      "description": "The MaaS access key for the API",
+      "type": ["string", "null"]
+    },
+    "accessSecret": {
+      "description": "The MaaS access secret for the API",
+      "type": ["string", "null"]
+    }
+  },
+
+  "required": [
+    "accessKey",
+    "accessSecret"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/maasNodeConfig.json
+++ b/schemas/config/v1/maasNodeConfig.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasNodeConfig.json",
+  "$$target": "maasNodeConfig.json",
+  "title": "MaaS Node Configuration",
+  "description": "Describes node configuration, some of which is specific to MaaS",
+
+  "properties": {
+    "name": {
+      "description": "Name of node for use by k2.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Type of node",
+      "enum": ["node"],
+      "type": "string"
+    },
+    "mounts": {
+      "description": "Additional mounts made in the node.",
+      "items": { "$ref": "maasNodeMountConfig.json" },
+      "type": "array"
+    },
+   "keypair": {
+     "type": "string"
+   },
+   "providerConfig": {
+      "$ref": "maasNodeProviderConfig.json"
+    },
+    "taints": {
+      "description": "List of MaaS taints to associate with the kubernetes node",
+      "items": { "$ref": "kubeNodeTaint.json" },
+      "type": "array"
+    }
+  },
+  "required": [
+    "name",
+    "providerConfig"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/maasNodeMountConfig.json
+++ b/schemas/config/v1/maasNodeMountConfig.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasNodeMountConfig.json",
+  "$$target": "maasNodeMountConfig.json",
+  "title": "Node Mount Configuration",
+  "description": "Describes a mount for a node.",
+
+  "properties": {
+    "device": {
+      "description": "The device to be mounted.",
+      "type": "string"
+    },
+    "path": {
+      "description": "The path to mount the device to.",
+      "type": "string"
+    },
+    "forceFormat": {
+      "description": "Whether the mount should be formatted after every boot.",
+      "type": "boolean"
+    }
+  },
+
+  "required": [
+    "device",
+    "path",
+    "forceFormat"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/maasNodeProviderConfig.json
+++ b/schemas/config/v1/maasNodeProviderConfig.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasNodeProviderConfig.json",
+  "$$target": "maasNodeProviderConfig.json",
+  "title": "MaaS Provider Configuration",
+  "description": "Describes MaaS specific provider configuration.",
+
+  "properties": {
+    "provider": {
+      "description": "Identifies who the provider is for configuration.",
+      "enum": [ "maas" ],
+      "type": "string"
+    },
+    "subnet": {
+      "description": "Identifies what subnets should be used.  These are names of subnets created elsewhere in the configuration.",
+      "items": { "type": "string" },
+      "type": "array"
+    },
+    "tags": {
+      "description": "List of MaaS tags to associate with the node.",
+      "items": { "$ref": "maasNodeTag.json" },
+      "type": "array"
+    },
+    "labels": {
+      "description": "List of Kubernetes labels to associate with the node.",
+      "items": { "$ref": "kubeNodeLabel.json" },
+      "type": "array"
+    },
+    "storage": {
+      "description": "List of storage devices to attach to the node.",
+      "items": { "$ref": "maasStorageDevice.json" },
+      "type": "array"
+    }
+  },
+
+  "required": [
+    "provider",
+    "subnet"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/maasNodeTag.json
+++ b/schemas/config/v1/maasNodeTag.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasNodeTag.json",
+  "$$target": "maasNodeTag.json",
+  "title": "MaaS Node Tag",
+  "description": "Describes an [MaaS node tag](http://docs.maas.amazon.com/MaaSEC2/latest/UserGuide/Using_Tags.html).",
+
+  "properties": {
+    "key": {
+      "description": "The MaaS tag's key name.",
+      "type": "string"
+    },
+    "value": {
+      "description": "The MaaS tag's value.",
+      "type": "string"
+    }
+  },
+
+  "required": [
+    "key",
+    "value"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/maasProviderConfig.json
+++ b/schemas/config/v1/maasProviderConfig.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasProviderConfig.json",
+  "$$target": "maasProviderConfig.json",
+  "title": "MaaS Provider Configuration",
+  "description": "Describes MaaS specific provider configuration.",
+
+  "properties": {
+    "name": {
+      "description": "The name of the configuration, for use within k2 configurations.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "The type of configuration this object it.",
+      "enum": [ "provider" ],
+      "type": "string"
+    },
+    "provider": {
+      "description": "The name of the provider for this provider setting.",
+      "enum": [ "maas" ],
+      "type": "string"
+    },
+    "type": {
+      "description": "Type of machine image deployment. For MaaS, only cloudinit is supported.",
+      "enum": [ "cloudinit" ],
+      "type": "string"
+    },
+    "resourcePrefix": {
+      "description": "Any prefix that should be prepended to resources in MaaS to make them easier to identify.",
+      "type": [ "string", "null" ]
+    },
+    "vpc": {
+      "description": "CIDR for the VPC for the cluster.",
+      "format": "cidr",
+      "type": "string",
+      "default": "10.0.0.0/16"
+    },
+    "authentication": { "$ref": "maasAuthenticationConfig.json" }
+
+  },
+
+  "required": [
+    "name",
+    "provider",
+    "type",
+    "resourcePrefix",
+    "vpc",
+    "authentication"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/maasStorageDevice.json
+++ b/schemas/config/v1/maasStorageDevice.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://judkins.house/apis/k2/v1/maasStorageDevice.json",
+  "$$target": "maasStorageDevice.json",
+  "title": "MaaS Storage Device",
+  "description": "Describes an MaaS storage device.",
+
+  "properties": {
+    "type": {
+      "description": "The type of storage",
+      "type": "string"
+    },
+    "device": {
+      "description": "The storage device",
+      "type": "string"
+    }
+  },
+
+  "required": [
+    "type",
+    "device"
+  ],
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/schemas/config/v1/nodeConfig.json
+++ b/schemas/config/v1/nodeConfig.json
@@ -4,10 +4,10 @@
   "$$target": "nodeConfig.json",
   "title": "Node Configuration",
   "description": "Describes the configuration of a node within a nodePool.",
-  
+
   "oneOf": [
     { "$ref": "awsNodeConfig.json" },
-    { "$ref": "gkeNodeConfig.json" }
+    { "$ref": "gkeNodeConfig.json" },
+    { "$ref": "maasNodeConfig.json" }
   ]
- 
 }

--- a/schemas/config/v1/providerConfig.json
+++ b/schemas/config/v1/providerConfig.json
@@ -7,6 +7,7 @@
 
   "oneOf": [
     { "$ref": "awsProviderConfig.json" },
-    { "$ref": "gkeProviderConfig.json" }
+    { "$ref": "gkeProviderConfig.json" },
+    { "$ref": "maasProviderConfig.json" }
   ]
 }


### PR DESCRIPTION
This PR and associated process will create a kubernetes cluster on AWS using Ubuntu via kraken.  This is a research project and should be treated as such.
 The process works as follows:

1. run `hack/dockerdev` to get into a good kraken-lib environment
1. run `bin\up.sh --generate <your config file>`
1. edit generated config file to only have `etcd`, `master` and `clusterNodes` nodePools
1. run `KRAKEN_EXTRA_VARS="distro=ubuntu" bin/up.sh --config <your config file> --tags pre_provider`
1. edit `bin\ubuntu-aws.py` to  to point to the cloud config files generated by the previous call to kraken lib on your machine
1. run `ubuntu-aws.py`
1. replace the existing cloud-config tarballs:
   1. cd to location of cloud-config files
   1. `rm *.gz`
   1. `gzip < etcd.cloud-config.yaml > etcd.cloud-config.yaml.gz`
   1. `gzip < master.cloud-config.yaml > master.cloud-config.yaml.gz`
   1. `gzip < clusterNodes.cloud-config.yaml > clusterNodes.cloud-config.yaml.gz`
1. run `KRAKEN_EXTRA_VARS="distro=ubuntu" bin/up.sh --config /Users/pat/.kraken/ubuntu-aws.yaml --tags provider_only` to create the physical infrastructure
1. get the CNAME for the master elb for this cluster
1. run `KRAKEN_EXTRA_VARS="distro=ubuntu" bin/up.sh --config /Users/pat/.kraken/ubuntu-aws.yaml --tags post_provider -k <master elb>` to configure the cluster

There is a bit of a race condition so sometimes you need to manually restart the kubelet on a worker node.  ssh to the node and run `systemctl restart kubelet`