### PR TITLE
Allow taints per nodepool

### DIFF
--- a/schemas/config/v1/nodePool.json
+++ b/schemas/config/v1/nodePool.json
@@ -31,7 +31,12 @@
     "nodeConfig": { "$ref": "nodeConfig.json" },
     "keyPair": { "$ref": "keyPair.json" },
     "autoScalingConfig": { "$ref": "autoScalingConfig.json" },
-    "schedulingConfig": {"$ref": "schedulingConfig.json"}
+    "schedulingConfig": {"$ref": "schedulingConfig.json"},
+    "taints": {
+      "description": "List of AWS taints to associate with the kubernetes node",
+      "items": { "$ref": "kubeNodeTaint.json" },
+      "type": "array"
+    }
   },
   "required": [
     "name",


### PR DESCRIPTION
Tainting nodepools was added in #758 but the schema does not reflect
that. This corrects that deficiency.