### PR TITLE
Revert "Allow taints per nodepool"

### DIFF
--- a/schemas/config/v1/nodePool.json
+++ b/schemas/config/v1/nodePool.json
@@ -31,12 +31,7 @@
     "nodeConfig": { "$ref": "nodeConfig.json" },
     "keyPair": { "$ref": "keyPair.json" },
     "autoScalingConfig": { "$ref": "autoScalingConfig.json" },
-    "schedulingConfig": {"$ref": "schedulingConfig.json"},
-    "taints": {
-      "description": "List of AWS taints to associate with the kubernetes node",
-      "items": { "$ref": "kubeNodeTaint.json" },
-      "type": "array"
-    }
+    "schedulingConfig": {"$ref": "schedulingConfig.json"}
   },
   "required": [
     "name",


### PR DESCRIPTION
Reverts samsung-cnct/kraken-lib#1026

I missed that taints are actually supposed to be under schedulingConfig