### PR TITLE
Remove clusters by API query in AWS & GCP

### DIFF
--- a/hack/kraken-teardown-aws.sh
+++ b/hack/kraken-teardown-aws.sh
@@ -107,7 +107,8 @@ delete_route53_zone () {
 
 describe_cluster_instances () {
   aws ${AWS_COMMON_ARGS} ec2 describe-instances \
-    --filter="Name=tag:KubernetesCluster, Values=$1" \
+    --filter "Name=tag:KubernetesCluster, Values=$1" \
+      "Name=instance-state-name, Values=running,stopped,pending,shutting-down" \
     --query="Reservations[*].Instances[*].{a:InstanceId, b:Tags[?Key=='Name']|[0].Value}"
 }
 

--- a/hack/kraken-teardown-aws.sh
+++ b/hack/kraken-teardown-aws.sh
@@ -149,7 +149,7 @@ list_elb_cluster_tags () {
   [ $# -gt 0 ] || return 0
 
   print_exec=''
-  test "${DEBUG}" -eq 1 && print_exec="-t"
+  test "${DEBUG:-0}" -eq 1 && print_exec="-t"
 
   # This is a pagination hack. LOL.
   echo "${@}" | tr -s ' ' '\n' | xargs ${print_exec} -n 20 -J % \

--- a/hack/kraken-teardown-aws.sh
+++ b/hack/kraken-teardown-aws.sh
@@ -7,7 +7,7 @@
 #   Goal: provide a means of tearing down Kraken clusters *without* access to
 #     the configuration files that generated them. 
 #   Means:
-#     Requires a cluster name as first and only argument.
+#     Requires a cluster name specified as command line argument.
 #     Queries AWS API, based on the `KubernetesCluster` tag whereever possible.
 #     Generates DELETE (equivalent) API calls in the correct order, to remove
 #       the cluster from AWS.

--- a/hack/kraken-teardown-aws.sh
+++ b/hack/kraken-teardown-aws.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# 
 #
-# NOTE: TODO: remove this comment after acceptance.
-# This script is currently in the proposal stage. 
+# This script generates a series of commands for removal of clusters. 
+#
 #   Goal: provide a means of tearing down Kraken clusters *without* access to
 #     the configuration files that generated them. 
+# 
 #   Means:
 #     Requires a cluster name specified as command line argument.
 #     Queries AWS API, based on the `KubernetesCluster` tag whereever possible.
@@ -19,7 +19,8 @@
 #       reference within the ASG Launch Configurations. If not found, they will 
 #       not be removed.
 #     The actual DELETE effects are masked by `echo` statements below.
-#       TODO: upon acceptance, remove the `echo` statements masking DELETE ops.
+#       The intent is to provide an easy way to validate the operations before execution.
+#       To actually execute deletion, simply pipe its output into another bash process.
 # 
 # See also:
 # https://github.com/samsung-cnct/docs/blob/master/cnct/common-tools/Manual%20Deletion%20of%20kraken%20Cluster%20Resources.md
@@ -47,6 +48,12 @@ cat <<EOF
   This script generates a series of AWS CLI commands, which should be directly
   executable to tear down the specified Kubernetes cluster, in the correct 
   order.
+
+  To actually execute the teardown, simply pipe this script's output into 
+  another bash instance, like so:
+
+    $0 -c CLUSTER_NAME | bash
+    
 EOF
 }
 

--- a/hack/kraken-teardown-gke.sh
+++ b/hack/kraken-teardown-gke.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-# NOTE: TODO: remove this comment after acceptance
-# This script is currently in the proposal stage.
+# This script generates a series of commands for removal of clusters.
+#
 #   Goal: provide a means of tearing down GKE Kraken clusters *without* access
 #     to the configuration files that generated them.
+# 
 #   Means: 
 #     Requires a deployment name, GCP zone and project as CLI arguments.
 #     Queries GCP API, interrogating the deployment for associated clusters.
@@ -11,6 +12,11 @@
 #       the cluster fform GKE/GCP.
 #     Should tolerate partially removed clusters, in which the deployment exists
 #       but the cluster has already been deleted.
+#
+#   Limitations:
+#     The script currently masks DELETE operations with `echo`; this is intentional.
+#       The intent is to provide an easy way to validate the operations before execution.
+#       To actually execute deletion, simply pipe its output into another bash process.
 #
 #
 
@@ -35,6 +41,12 @@ cat <<EOF
   This script generates a series of gcloud CLI commands, which should be directly
   executable to tear down the specified Kubernetes cluster, in the correct 
   order.
+
+  To actually execute the teardown, simply pipe this script's output into 
+  another bash instance, like so:
+
+    $0 -c DEPLOYMENTNAME -z GCP_ZONE -p GCP_PROJECT | bash
+
 EOF
 }
 

--- a/hack/kraken-teardown-gke.sh
+++ b/hack/kraken-teardown-gke.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+
+# NOTE: TODO: remove this comment after acceptance
+# This script is currently in the proposal stage.
+#   Goal: provide a means of tearing down GKE Kraken clusters *without* access
+#     to the configuration files that generated them.
+#   Means: 
+#     Requires a deployment name, GCP zone and project as CLI arguments.
+#     Queries GCP API, interrogating the deployment for associated clusters.
+#     Generates DELETE (equivalent) API calls in the correct order, to remove
+#       the cluster fform GKE/GCP.
+#     Should tolerate partially removed clusters, in which the deployment exists
+#       but the cluster has already been deleted.
+#
+#
+
+
+# Exit when a command fails, and when referenced variables are unset.
+set -o errexit
+set -o pipefail
+set -o nounset
+
+test "${DEBUG:-0}" -gt 0 && set -x
+
+usage(){
+cat <<EOF
+  Usage: $0 -c DEPLOYMENT_NAME -z GCP_ZONE -p GCP_PROJECT
+
+  - GCP_ZONE defaults to "us-east1-b"
+  - GCP_PROJECT can be specified by name, rather than ID number
+
+  Query Google Cloud API to identify resources related to Kubernetes clusters, 
+  identified primarily by the associated deployment.
+
+  This script generates a series of gcloud CLI commands, which should be directly
+  executable to tear down the specified Kubernetes cluster, in the correct 
+  order.
+EOF
+}
+
+info() {
+  [ "${VERBOSE}" -gt 0 ] && echo "# $@" >&2 || return 0
+}
+
+fail(){
+  echo "[FAIL] $2" >&2
+  return $1
+}
+
+delete_deployment () {
+    echo gcloud deployemnt-manager deployments delete "$1" \
+        --project "${2}" --zone "${3}"
+}
+
+delete_cluster () {
+    echo gcloud container clusters delete "$1" \
+        --project "${2}" --zone "${3}"
+}
+
+list_deployments_by_name () {
+    filter_arg=""
+    [ $# -gt 0 ] && filter_arg="--filter=name=${1}"
+    gcloud deployment-manager deployments list \
+        --project "${2}" ${filter_arg} \
+        --format="value(name,operation.status,manifest)"
+}
+
+list_clusters_by_deployment () {
+    gcloud deployment-manager deployments describe "$1" \
+        --project "${2}" \
+        --format="value(resources[].name, resources[].type)" \
+        | awk '{ if($2 == "container.v1.cluster") { print $1 } }'
+}
+
+describe_deployed_cluster () {
+    # This is allowed to fail, because deployments may specify clusters have
+    # have ALREADY been deleted
+    gcloud container clusters describe "$1" \
+        --zone="${3}" --project="${2}" \
+        --format="value(name,status,zone)" 2>/dev/null || true
+}
+
+
+delete_cluster_artifacts () {
+
+    local clusters_to_kill
+    local zone="$2"
+    local project="$3"
+
+    clusters_to_kill=`mktemp /tmp/gkeclusters_delete.XXXXX`
+
+    while read dname status manifest; do
+
+        while read cname; do
+            describe_deployed_cluster "${cname}" "${project}" "$zone" \
+                | grep RUNNING >> ${clusters_to_kill} \
+                || true
+        done < <(list_clusters_by_deployment "${dname}" "${project}" "$zone")
+
+        delete_deployment "${dname}" "$project" "$zone"
+        
+    done < <(list_deployments_by_name "$1" "$project")
+
+    while read cname status zone; do
+        delete_cluster "${cname}" "${project}" "${zone}"
+    done < <(sort ${clusters_to_kill} | uniq)
+
+
+    rm ${clusters_to_kill}
+}
+
+
+main () {
+    local DEPLOYMENT_NAME=""
+    local GCP_PROJECT=""
+    local GCP_ZONE="us-east1-b"
+
+    while builtin getopts ":c:z:p:h" OPT "${@}"; do
+        case "$OPT" in
+            c) DEPLOYMENT_NAME="${OPTARG}";;
+            z) GCP_ZONE="${OPTARG}";;
+            p) GCP_PROJECT="${OPTARG}";;
+            h) usage ; exit 0 ;;
+            \?) fail 1 "-$OPTARG is an invalid option";;
+            :) fail 2 "-$OPTARG is missing the required parameter";;
+        esac
+    done
+
+    if [ -n "${DEPLOYMENT_NAME}" -a -n "${GCP_PROJECT}" ]; then
+        delete_cluster_artifacts "${DEPLOYMENT_NAME}" "${GCP_ZONE}" "${GCP_PROJECT}"
+    else
+        usage
+        exit 1
+    fi
+
+}
+
+
+
+main "${@:-NONE}"

--- a/hack/kraken-teardown.sh
+++ b/hack/kraken-teardown.sh
@@ -1,0 +1,201 @@
+#!/bin/sh
+
+# NOTE: TODO: remove this comment after acceptance.
+# This script is currently in the proposal stage. 
+#   Goal: provide a means of tearing down Kraken clusters *without* access to
+#     the configuration files that generated them. 
+#   Means:
+#     Requires a cluster name as first and only argument.
+#     Queries AWS API, based on the `KubernetesCluster` tag whereever possible.
+#     Generates DELETE (equivalent) API calls in the correct order, to remove
+#       the cluster from AWS.
+#     Should tolerate partially removed clusters in some cases, insofar as 
+#       querying their associated elements will simply produce empty sets.
+#
+#   Limitations:
+#     The identification of IAM roles to delete is predicated upon their 
+#       reference within the ASG Launch Configurations. If not found, they will 
+#       not be removed.
+#     The actual DELETE effects are masked by `echo` statements below.
+#       TODO: upon acceptance, remove the `echo` statements masking DELETE ops.
+# 
+
+AWS_REGION=${AWS_REGION:-us-east-2}
+AWS_COMMON_ARGS="--region=${AWS_REGION} --output=text"
+
+info() {
+  [ "${VERBOSE:-0}" -gt 0 ] && echo "$@" >&2
+}
+
+delete_asg () {
+  info "Deleting ASG: $1"  
+  echo aws autoscaling delete-auto-scaling-group --auto-scaling-group-name $1
+}
+
+delete_launchconfig () {
+  info "Deleting Launch Configuration: $1"
+  echo aws autoscaling delete-launch-configuration --launch-configuration-name $1
+}
+
+delete_keypair () {
+  info "Deleting Key Pair: $1"
+  echo aws ec2 delete-key-pair --key-name $1
+}
+
+delete_instances () {
+  info "Terminating Instances: $@"
+  echo aws ${AWS_COMMON_ARGS} ec2 terminate-instances  --instance-ids "$@" 
+}
+
+delete_elb (){ 
+  info "Deleting LoadBalancer: $1"
+  echo aws ${AWS_COMMON_ARGS} elb delete-load-balancher --load-balancer-name "$1"
+}
+
+delete_vpc () {
+  info "Deleting VPC: $1"
+  echo aws ${AWS_COMMON_ARGS} vpc delete-vpc --vpc-id $1
+}
+
+delete_iam_profile () {
+  info "Deleting IAM Profile: $1"
+  echo aws iam delete-instance-profile --instance-profile-name $1
+}
+
+delete_iam_role () {
+  info "Deleting IAM Role: $1"
+  echo aws iam delete-role --role-name $1
+}
+
+delete_route53_zone () {
+  info "Deleting Route53 zone: $1"
+  echo aws route53 delete-hosted-zone --id $1
+}
+
+describe_cluster_instances () {
+  aws ${AWS_COMMON_ARGS} ec2 describe-instances \
+    --filter="Name=tag:KubernetesCluster, Values=$1" \
+    --query="Reservations[*].Instances[*].{a:InstanceId, b:Tags[?Key=='Name']|[0].Value}"
+}
+
+describe_launchconfig () {
+  aws ${AWS_COMMON_ARGS} autoscaling describe-launch-configurations \
+    --launch-configuration-name $1 \
+    --query "LaunchConfigurations[*].{a:LaunchConfigurationName, b:KeyName, c:IamInstanceProfile}"
+}
+
+describe_asg () {
+  # Produce fields in specific order: GroupName, ARN
+  # Columns are ordered alphabetically to their aliases (a and b, here)
+  aws ${AWS_COMMON_ARGS} autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names $@ \
+    --query 'AutoScalingGroups[*].{a:AutoScalingGroupName, b:AutoScalingGroupARN, c:LaunchConfigurationName}' 
+}
+
+list_elb_all () {
+  aws ${AWS_COMMON_ARGS} elb describe-load-balancers \
+    --query="LoadBalancerDescriptions[*].{a:LoadBalancerName}"
+}
+
+list_elb_cluster_tags () {
+  aws ${AWS_COMMON_ARGS} elb describe-tags --load-balancer-names $@  \
+    --query="TagDescriptions[*].{a:LoadBalancerName, b:Tags[?Key=='KubernetesCluster']|[0].Value}"
+}
+
+list_elb_by_cluster_tag (){ 
+  list_elb_cluster_tags $(list_elb_all) | awk "{ if(\$2 == \"$1\"){ print \$1 } }"
+}
+
+list_asg_by_cluster_tag () {
+  aws ${AWS_COMMON_ARGS} autoscaling describe-tags \
+    --filters "Name=Key, Values=KubernetesCluster" "Name=Value, Values=$1" \
+    --query "Tags[*].{a:Value, b:ResourceId, c:ResourceType}" \
+      | awk "{ if(\$3 == \"auto-scaling-group\") { print \$2 } }"
+}
+
+list_vpc_by_cluster_tag () {
+  aws ${AWS_COMMON_ARGS} ec2 describe-vpcs \
+    --filter "Name=tag:KubernetesCluster, Values=$1" \
+    --query="Vpcs[*].{a:VpcId, b:Tags[?Key=='Name']|[0].Value}"
+}
+
+list_iam_roles_for_profile () {
+  aws ${AWS_COMMON_ARGS} iam get-instance-profile  --instance-profile-name "$1" \
+    --query "InstanceProfile.{a:Roles[*]|[0].RoleName, b:InstanceProfileName}"
+}
+
+list_route53_zones_by_name () {
+  aws ${AWS_COMMON_ARGS} route53 list-hosted-zones \
+    --query="HostedZones[*].{b:Id, a:Name}" --max-items=10000  \
+      | awk "{ if(\$1 == \"$1\") { print \$2 }}"
+}
+
+
+delete_cluster_artifacts () {
+  # Expects first argument to be the cluster name.
+
+  roles_to_delete=`mktemp /tmp/delete_roles.XXXXX`
+
+  # Iterate through autoscaling groups for this cluster.
+  list_asg_by_cluster_tag "$1" | while read asgname; do
+
+    describe_asg ${asgname} | while read asgname arn lcn; do
+        describe_launchconfig $lcn | while read lcn kpn iamprofile; do
+          # Remove key pairs
+          delete_keypair ${kpn}
+          
+          # Queue IAM role  for deletion(if exists)
+          echo ${iamprofile} >> $roles_to_delete
+        done
+        
+        # Remove launch configuration
+        delete_launchconfig ${lcn}
+    
+    done 
+
+    # Remove the autoscaling group
+    delete_asg ${asgname}
+  done  
+  
+  # Remove remaining EC2 instances
+  delete_instances `describe_cluster_instances $1 | awk '{ print $1 }'`
+
+  # Remove associated load balancers
+  list_elb_by_cluster_tag "$1" | while read elb; do
+    delete_elb $elb
+  done
+
+  # TODO: Remove associated network interfaces
+
+  # Remove associated VPC
+  list_vpc_by_cluster_tag "$1" | while read vpcid vpcName; do
+    delete_vpc $vpcid
+  done
+
+  # Remove associated IAM roles
+  sort $roles_to_delete | uniq | while read iamprofile; do
+    list_iam_roles_for_profile $iamprofile | while read role profile; do
+      delete_iam_profile $profile
+      delete_iam_role $role
+    done
+  done
+
+  # Remove zones associated with the cluster
+  list_route53_zones_by_name "$1.internal." | while read zone; do
+    delete_route53_zone $zone
+  done
+
+  rm -v $roles_to_delete
+}
+
+
+
+
+main () {
+  set -e
+  delete_cluster_artifacts "${1:-$CLUSTER_NAME}"
+  set +e
+}
+
+
+main "${@}"

--- a/hack/kraken-teardown.sh
+++ b/hack/kraken-teardown.sh
@@ -49,7 +49,7 @@ delete_instances () {
 
 delete_elb (){ 
   info "Deleting LoadBalancer: $1"
-  echo aws ${AWS_COMMON_ARGS} elb delete-load-balancher --load-balancer-name "$1"
+  echo aws ${AWS_COMMON_ARGS} elb delete-load-balancer --load-balancer-name "$1"
 }
 
 delete_vpc () {

--- a/hack/kraken-teardown.sh
+++ b/hack/kraken-teardown.sh
@@ -19,7 +19,10 @@
 #     The actual DELETE effects are masked by `echo` statements below.
 #       TODO: upon acceptance, remove the `echo` statements masking DELETE ops.
 # 
-
+# See also:
+# https://github.com/samsung-cnct/docs/blob/master/cnct/common-tools/Manual%20Deletion%20of%20kraken%20Cluster%20Resources.md
+# This script intends to obviate the need for the documentation above. :)
+#
 AWS_REGION=${AWS_REGION:-us-east-2}
 AWS_COMMON_ARGS="--region=${AWS_REGION} --output=text"
 

--- a/hack/kraken-teardown.sh
+++ b/hack/kraken-teardown.sh
@@ -43,6 +43,7 @@ delete_keypair () {
 }
 
 delete_instances () {
+  [ $# -gt 0 ] || return 0
   info "Terminating Instances: $@"
   echo aws ${AWS_COMMON_ARGS} ec2 terminate-instances  --instance-ids "$@" 
 }
@@ -87,6 +88,7 @@ describe_launchconfig () {
 describe_asg () {
   # Produce fields in specific order: GroupName, ARN
   # Columns are ordered alphabetically to their aliases (a and b, here)
+  [ $# -gt 0 ] || return 0
   aws ${AWS_COMMON_ARGS} autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names $@ \
     --query 'AutoScalingGroups[*].{a:AutoScalingGroupName, b:AutoScalingGroupARN, c:LaunchConfigurationName}' 
@@ -98,6 +100,7 @@ list_elb_all () {
 }
 
 list_elb_cluster_tags () {
+  [ $# -gt 0 ] || return 0
   aws ${AWS_COMMON_ARGS} elb describe-tags --load-balancer-names $@  \
     --query="TagDescriptions[*].{a:LoadBalancerName, b:Tags[?Key=='KubernetesCluster']|[0].Value}"
 }


### PR DESCRIPTION
This is a first stab at the API logic for tearing down clusters that CI leaves (at least) partially deployed after a test failure, currently, and provides for a few other related use-cases.

This first draft _DOES NOT_ actually remove anything, it simply queries the API and prints the proposed `aws` and `gcloud` commands, for review. I'll comment here shortly with example output.

Please raise any concerns here in the PR. 

**Update**: the behavior of `echo`ing the proposed `DELETE` operations is now documented, with the intent of being executed separately; done simply with `| bash` for CI purposes.