### PR TITLE
always save artifacts from 'cluster up'

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,6 +140,7 @@ test:cloud-aws:
   stage: test
   image: $KRAKEN_TOOLS
   artifacts:
+    when: always
     paths:
       - $CI_PROJECT_DIR/cluster/aws/**
     expire_in: 14 day
@@ -152,6 +153,7 @@ test:cloud-gke:
   stage: test
   image: $KRAKEN_TOOLS
   artifacts:
+    when: always
     paths:
       - $CI_PROJECT_DIR/cluster/gke/**
     expire_in: 14 day


### PR DESCRIPTION
currently we only save the state from 'up' commands when the command succeeds.  however, if the etcd cluster fails to form, the cluster up fails.  

we still need the artifact here so that the down command will work.