### PR TITLE
[BAC-102] Add kube bench tests to CI (#660)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,7 +269,7 @@ test-security:benchmark:
     expire_in: 14 day
   allow_failure: true
   script:
-    - build-scripts/benchmark-tests "${KUBERNETES_E2E_TEST_VERSION}"
+    - build-scripts/benchmark-tests "$CI_PROJECT_DIR/cluster/aws-$KUBERNETES_E2E_TEST_VERSION"
 
 test-security:benchmark-minus-one:
   stage: test-security
@@ -283,7 +283,7 @@ test-security:benchmark-minus-one:
     expire_in: 14 day
   allow_failure: true
   script:
-    - build-scripts/benchmark-tests "${KUBERNETES_E2E_TEST_VERSION_MINUS_ONE}"
+    - build-scripts/benchmark-tests "$CI_PROJECT_DIR/cluster/aws-$KUBERNETES_E2E_TEST_VERSION_MINUS_ONE"
 
 test-security:benchmark-minus-two:
   stage: test-security
@@ -297,7 +297,7 @@ test-security:benchmark-minus-two:
     expire_in: 14 day
   allow_failure: true
   script:
-    - build-scripts/benchmark-tests "${KUBERNETES_E2E_TEST_VERSION_MINUS_TWO}"
+    - build-scripts/benchmark-tests "$CI_PROJECT_DIR/cluster/aws-$KUBERNETES_E2E_TEST_VERSION_MINUS_TWO"
 
 test-e2e:e2e:
   stage: test-e2e

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,7 @@ stages:
   - config-generation
   - pre-test
   - test
+  - test-security
   - test-e2e
   - cleanup
   - build
@@ -255,6 +256,48 @@ test:cloud-gke:
   script:
     - test -f "$CI_PROJECT_DIR/cluster/gke-$KUBERNETES_E2E_TEST_VERSION/config.yaml" || exit $?
     - ./bin/up.sh --config $CI_PROJECT_DIR/cluster/gke-$KUBERNETES_E2E_TEST_VERSION/config.yaml --output $CI_PROJECT_DIR/cluster/gke-$KUBERNETES_E2E_TEST_VERSION/ --verbose "-vvv"
+
+test-security:benchmark:
+  stage: test-security
+  only:
+    - tags
+    - branches
+  image: $KRAKEN_TOOLS
+  artifacts:
+    paths:
+      - $CI_PROJECT_DIR/build/tests/**
+    expire_in: 14 day
+  allow_failure: true
+  script:
+    - build-scripts/benchmark-tests "${KUBERNETES_E2E_TEST_VERSION}"
+
+test-security:benchmark-minus-one:
+  stage: test-security
+  only:
+    - "/master/"
+    - "/.*test-all.*/"
+  image: $KRAKEN_TOOLS
+  artifacts:
+    paths:
+      - $CI_PROJECT_DIR/build/tests/**
+    expire_in: 14 day
+  allow_failure: true
+  script:
+    - build-scripts/benchmark-tests "${KUBERNETES_E2E_TEST_VERSION_MINUS_ONE}"
+
+test-security:benchmark-minus-two:
+  stage: test-security
+  only:
+    - "/master/"
+    - "/.*test-all.*/"
+  image: $KRAKEN_TOOLS
+  artifacts:
+    paths:
+      - $CI_PROJECT_DIR/build/tests/**
+    expire_in: 14 day
+  allow_failure: true
+  script:
+    - build-scripts/benchmark-tests "${KUBERNETES_E2E_TEST_VERSION_MINUS_TWO}"
 
 test-e2e:e2e:
   stage: test-e2e

--- a/build-scripts/benchmark-conf/1.6/master.yaml
+++ b/build-scripts/benchmark-conf/1.6/master.yaml
@@ -1,0 +1,966 @@
+---
+controls:
+version: 1.6
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+- id: 1.1
+  text: "API Server"
+  checks:
+    - id: 1.1.1
+      text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "allow-privileged"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set 
+              the KUBE_ALLOW_PRIV parameter to \"--allow-privileged=false\""
+      scored: true
+
+    - id: 1.1.2
+      text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--anonymous-auth"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set 
+              the KUBE_API_ARGS parameter to \"--anonymous-auth=false\""
+      scored: true
+
+    - id: 1.1.3
+      text: "Ensure that the --basic-auth-file argument is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--basic-auth-file"
+          set: false
+      remediation: "Follow the documentation and configure alternate mechanisms for 
+              authentication. Then, edit the $apiserverconf file on the master 
+              node and remove the \"--basic-auth-file=<filename>\" argument from the 
+              KUBE_API_ARGS parameter."
+      scored: true
+
+    - id: 1.1.4
+      text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag:  "--insecure-allow-any-token"
+          set: false
+      remediation: "Edit the $apiserverconf file on the master node and remove 
+              the --insecure-allow-any-token argument from the KUBE_API_ARGS parameter."
+      scored: true
+
+    - id: 1.1.5
+      text: "Ensure that the --kubelet-https argument is set to true (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests: 
+        bin_op: or
+        test_items:
+        - flag: "--kubelet-https"
+          compare:
+            op: eq
+            value: true
+          set: true
+        - flag: "--kubelet-https"
+          set: false
+      remediation: "Edit the $apiserverconf file on the master node and remove 
+              the --kubelet-https argument from the KUBE_API_ARGS parameter."
+      scored: true
+
+    - id: 1.1.6
+      text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--insecure-bind-address"
+          set: false
+      remediation: "Edit the $apiserverconf file on the master node and remove 
+              the --insecure-bind-address argument from the KUBE_API_ADDRESS parameter."
+      scored: true
+
+    - id: 1.1.7
+      text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--insecure-port"
+          compare:
+            op: eq
+            value: 0
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set
+              --insecure-port=0 in the KUBE_API_PORT parameter."
+      scored: true
+
+    - id: 1.1.8
+      text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests: 
+        bin_op: or
+        test_items:
+          - flag:  "--secure-port"
+            compare:
+              op: gt
+              value: 0
+            set: true
+          - flag: "--secure-port"
+            set: false
+      remediation: "Edit the $apiserverconf file on the master node and either 
+              remove the --secure-port argument from the KUBE_API_ARGS parameter or set 
+              it to a different desired port."
+      scored: true
+
+    - id: 1.1.9
+      text: "Ensure that the --profiling argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--profiling"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--profiling=false\""
+      scored: true
+
+    - id: 1.1.10
+      text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--repair-malformed-updates"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--repair-malformed-updates=false\""
+      scored: true
+
+    - id: 1.1.11
+      text: "Ensure that the admission control policy is not set to AlwaysAdmit (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: nothave
+            value: AlwaysAdmit 
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to a value that does not include AlwaysAdmit"
+      scored: true
+ 
+    - id: 1.1.12
+      text: "Ensure that the admission control policy is set to AlwaysPullImages (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "AlwaysPullImages"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=...,AlwaysPullImages,...\""
+      scored: true
+ 
+    - id: 1.1.13
+      text: "Ensure that the admission control policy is set to DenyEscalatingExec (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "DenyEscalatingExec"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=...,DenyEscalatingExec,...\""
+      scored: true
+
+    - id: 1.1.14
+      text: "Ensure that the admission control policy is set to SecurityContextDeny (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "SecurityContextDeny"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=...,SecurityContextDeny,...\""
+      scored: true
+
+    - id: 1.1.15
+      text: "Ensure that the admission control policy is set to NamespaceLifecycle (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "admission-control"
+          compare:
+            op: has
+            value: "NamespaceLifecycle"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=NamespaceLifecycle,...\""
+      scored: true
+
+    - id: 1.1.16
+      text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-path"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-path=<filename>\""
+      scored: true
+
+    - id: 1.1.17
+      text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-maxage"
+          compare:
+            op: gte
+            value: 30
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-maxage=30\""
+      scored: true
+
+    - id: 1.1.18
+      text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-maxbackup"
+          compare:
+            op: gte
+            value: 10
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-maxbackup=10\""
+      scored: true
+
+    - id: 1.1.19
+      text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-maxsize"
+          compare:
+            op: gte
+            value: 100
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-maxsize=100\""
+      scored: true
+
+    - id: 1.1.20
+      text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--authorization-mode"
+          compare:
+            op: nothave
+            value: "AlwaysAllow"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to values other than \"--authorization-mode=AlwaysAllow\""
+      scored: true
+
+    - id: 1.1.21
+      text: "Ensure that the --token-auth-file parameter is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--token-auth-file"
+          set: false
+      remediation: "Follow the documentation and configure alternate mechanisms for authentication. 
+              Then, edit the $apiserverconf file on the master node and remove the 
+              \"--tokenauth-file=<filename>\" argument from the KUBE_API_ARGS parameter."
+      scored: true
+ 
+    - id: 1.1.22
+      text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--kubelet-certificate-authority"
+          set: true
+      remediation: "Follow the Kubernetes documentation and setup the TLS connection between 
+              the apiserver and kubelets. Then, edit the $apiserverconf file on the 
+              master node and set the KUBE_API_ARGS parameter to 
+              \"--kubelet-certificate-authority=<ca-string>\""
+      scored: true
+
+    - id: 1.1.23
+      text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        bin_op: and
+        test_items:
+        - flag: "--kubelet-client-certificate"
+          set: true
+        - flag: "--kubelet-client-key"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver 
+              and kubelets. Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--kubelet-clientcertificate=<path/to/client-certificate-file>\" 
+              and \"--kubelet-clientkey=<path/to/client-key-file>\""
+      scored: true
+
+    - id: 1.1.24
+      text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--service-account-lookup"
+          compare:
+            op: eq
+            value: true
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS parameter 
+              to \"--service-account-lookup=true\""
+      scored: true
+ 
+    - id: 1.1.25
+      text: "Ensure that the admission control policy is set to PodSecurityPolicy (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "PodSecurityPolicy"
+          set: true
+      remediation: "Follow the documentation and create Pod Security Policy objects as per your environment. 
+              Then, edit the $apiserverconf file on the master node and set the KUBE_ADMISSION_CONTROL 
+              parameter to \"--admission-control=...,PodSecurityPolicy,...\""
+      scored: true
+
+    - id: 1.1.26
+      text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--service-account-key-file"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS 
+              parameter to \"--service-account-key-file=<filename>\""
+      scored: true
+
+    - id: 1.1.27
+      text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        bin_op: and
+        test_items:
+        - flag: "--etcd-certfile"
+          set: true
+        - flag: "--etcd-keyfile"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver 
+              and etcd. Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to include \"--etcd-certfile=<path/to/clientcertificate-file>\" 
+              and \"--etcd-keyfile=<path/to/client-key-file>\""
+      scored: true
+ 
+    - id: 1.1.28
+      text: "Ensure that the admission control policy is set to ServiceAccount (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "ServiceAccount"
+          set: true
+      remediation: "Follow the documentation and create ServiceAccount objects as per your environment. 
+              Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admissioncontrol=...,ServiceAccount,...\""
+      scored: true
+
+    - id: 1.1.29
+      text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        bin_op: and
+        test_items:
+        - flag: "--tls-cert-file"
+          set: true
+        - flag: "--tls-private-key-file"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. 
+              Then, edit the $apiserverconf file on the master node and set the KUBE_API_ARGS parameter to 
+              include \"--tls-cert-file=<path/to/tls-certificatefile>\" and 
+              \"--tls-private-key-file=<path/to/tls-key-file>\""
+      scored: true
+
+    - id: 1.1.30
+      text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--client-ca-file"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. 
+              Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to include \"--client-ca-file=<path/to/client-ca-file>\""
+      scored: true
+
+    - id: 1.1.31
+      text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--etcd-cafile"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver 
+              and etcd. Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to include \"--etcd-cafile=<path/to/ca-file>\""
+      scored: true
+
+- id: 1.2
+  text: "Scheduler"
+  checks:
+    - id: 1.2.1
+      text: "Ensure that the --profiling argument is set to false (Scored)"
+      audit: "ps -ef | grep $schedulerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--profiling"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $schedulerconf file on the master node and set the KUBE_SCHEDULER_ARGS 
+              parameter to \"--profiling=false\""
+      scored: true
+
+- id: 1.3
+  text: "Controller Manager"
+  checks:
+    - id: 1.3.1
+      text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--terminated-pod-gc-threshold"
+            set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to \"--terminated-pod-gcthreshold=<appropriate-number>\""
+      scored: true
+ 
+    - id: 1.3.2
+      text: "Ensure that the --profiling argument is set to false (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--profiling"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to \"--profiling=false\""
+      scored: true
+
+    - id: 1.3.3
+      text: "Ensure that the --insecure-experimental-approve-all-kubelet-csrs-for-group argument is not set (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--insecure-experimental-approve-all-kubelet-csrs-for-group"
+          set: false
+      remediation: "Edit the /etc/kubernetes/controller-manager file on the master node and remove the 
+              --insecure-experimental-approve-all-kubelet-csrs-for-group argument from the
+              KUBE_CONTROLLER_MANAGER_ARGS parameter."
+      scored: true
+ 
+    - id: 1.3.4
+      text: "Ensure that the --use-service-account-credentials argument is set"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--use-service-account-credentials"
+          compare:
+            op: eq
+            value: true
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to --use-service-account-credentials=true"
+      scored: true
+
+    - id: 1.3.5
+      text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--service-account-private-key-file"
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to --service-account-private-keyfile=<filename>"
+      scored: true
+
+    - id: 1.3.6
+      text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--root-ca-file"
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to include --root-ca-file=<file>"
+      scored: true
+ 
+- id: 1.4
+  text: "Configure Files"
+  checks:
+    - id: 1.4.1
+      text: "Ensure that the apiserver file permissions are set to 644 or more restrictive (Scored)"
+      # audit: "/bin/bash -c 'if test -e $apiserverconf; then stat -c %a $apiserverconf; fi'"
+      audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %a $apiserverconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $apiserverconf"
+      scored: true
+
+    - id: 1.4.2
+      text: "Ensure that the apiserver file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $apiserverconf"
+      scored: true
+
+    - id: 1.4.3
+      text: "Ensure that the config file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $config; then stat -c %a $config; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $config"
+      scored: true
+
+    - id: 1.4.4
+      text: "Ensure that the config file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $config; then stat -c %U:%G $config; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $config"
+      scored: true
+
+    - id: 1.4.5
+      text: "Ensure that the scheduler file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $schedulerconf"
+      scored: true
+
+    - id: 1.4.6
+      text: "Ensure that the scheduler file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: "root:root"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $schedulerconf"
+      scored: true
+
+    - id: 1.4.7
+      text: "Ensure that the etcd.conf file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $etcdconf"
+      scored: true
+
+    - id: 1.4.8
+      text: "Ensure that the etcd.conf file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $etcdconf"
+      scored: true
+
+    - id: 1.4.9
+      text: "Ensure that the flanneld file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $flanneldconf; then stat -c %a $flanneldconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $flanneldconf"
+      scored: true
+
+    - id: 1.4.10
+      text: "Ensure that the flanneld file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $flanneldconf; then stat -c %U:%G $flanneldconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $flanneldconf"
+      scored: true
+      
+    - id: 1.4.11
+      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %a"
+      tests:
+        test_items:
+        - flag: "700"
+          compare:
+            op: eq
+            value: "700"
+          set: true
+      remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+              from the below command:\n
+              ps -ef | grep $etcdbin\n
+              Run the below command (based on the etcd data directory found above). For example,\n
+              chmod 700 /var/lib/etcd/default.etcd"
+      scored: true
+
+    - id: 1.4.12
+      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %U:%G"
+      tests:
+        test_items:
+        - flag: "etcd:etcd"
+          set: true
+      remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+              from the below command:\n
+                      ps -ef | grep etcd\n
+              Run the below command (based on the etcd data directory found above). For example,\n
+                      chown etcd:etcd /var/lib/etcd/default.etcd"
+      scored: true
+
+- id: 1.5
+  text: "etcd"
+  checks:
+    - id: 1.5.1
+      text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--cert-file"
+            set: true
+          - flag:  "--key-file"
+            set: true
+      remediation: "Follow the etcd service documentation and configure TLS encryption."
+      scored: true
+
+    - id: 1.5.2
+      text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--client-cert-auth"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Edit the etcd envrironment file (for example, $etcdconf) on the 
+              etcd server node and set the ETCD_CLIENT_CERT_AUTH parameter to \"true\". 
+              Edit the etcd startup file (for example, /etc/systemd/system/multiuser.target.wants/etcd.service) 
+              and configure the startup parameter for --clientcert-auth and set it to \"${ETCD_CLIENT_CERT_AUTH}\""
+      scored: true
+
+    - id: 1.5.3
+      text: "Ensure that the --auto-tls argument is not set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--auto-tls"
+            set: false
+          - flag: "--auto-tls"
+            compare:
+              op: neq
+              value: true
+      remediation: "Edit the etcd environment file (for example, $etcdconf) on the etcd server 
+              node and comment out the ETCD_AUTO_TLS parameter. Edit the etcd startup file (for example, 
+              /etc/systemd/system/multiuser.target.wants/etcd.service) and remove the startup parameter 
+              for --auto-tls."
+      scored: true
+
+    - id: 1.5.4
+      text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--peer-cert-file"
+            set: true
+          - flag: "--peer-key-file"
+            set: true
+      remediation: "Note: This recommendation is applicable only for etcd clusters. If you are using only 
+              one etcd server in your environment then this recommendation is not applicable. 
+              Follow the etcd service documentation and configure peer TLS encryption as appropriate for 
+              your etcd cluster."
+      scored: true
+
+    - id: 1.5.5
+      text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--peer-client-cert-auth"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Note: This recommendation is applicable only for etcd clusters. If you are using only 
+              one etcd server in your environment then this recommendation is not applicable.
+              Edit the etcd environment file (for example, $etcdconf) on the etcd server node 
+              and set the ETCD_PEER_CLIENT_CERT_AUTH parameter to \"true\". Edit the etcd startup file 
+              (for example, /etc/systemd/system/multiuser.target.wants/etcd.service) and configure the 
+              startup parameter for --peer-client-cert-auth and set it to \"${ETCD_PEER_CLIENT_CERT_AUTH}\""
+      scored: true
+
+    - id: 1.5.6
+      text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--peer-auto-tls"
+            set: false
+          - flag: "--peer-auto-tls"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Note: This recommendation is applicable only for etcd clusters. 
+              If you are using only one etcd server in your environment then this recommendation is 
+              not applicable. Edit the etcd environment file (for example, $etcdconf) 
+              on the etcd server node and comment out the ETCD_PEER_AUTO_TLS parameter. 
+              Edit the etcd startup file (for example, /etc/systemd/system/multiuser.target.wants/etcd.service) 
+              and remove the startup parameter for --peer-auto-tls."
+      scored: true
+
+    - id: 1.5.7
+      text: "Ensure that the --wal-dir argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--wal-dir"
+            set: true
+      remediation: "Edit the etcd environment file (for example, $etcdconf) on the etcd server node 
+              and set the ETCD_WAL_DIR parameter as appropriate. Edit the etcd startup file (for example, 
+              /etc/systemd/system/multiuser.target.wants/etcd.service) and configure the startup parameter for 
+              --wal-dir and set it to \"${ETCD_WAL_DIR}\""
+      scored: true
+
+    - id: 1.5.8
+      text: "Ensure that the --max-wals argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--max-wals"
+            compare:
+              op: eq
+              value: 0
+            set: true
+      remediation: "Edit the etcd environment file (for example, $etcdconf) on the etcd server node 
+              and set the ETCD_MAX_WALS parameter to 0. Edit the etcd startup file (for example, 
+              /etc/systemd/system/multiuser.target.wants/etcd.service) and configure the startup parameter 
+              for --max-wals and set it to \"${ETCD_MAX_WALS}\"."
+      scored: true
+
+    - id: 1.5.9
+      text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--trusted-ca-file"
+            set: true
+      remediation: "Follow the etcd documentation and create a dedicated certificate authority setup for the 
+              etcd service."
+      scored: false 
+
+- id: 1.6
+  text: "General Security Primitives"
+  checks:
+    - id: 1.6.1
+      text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
+      type: "manual"
+      remediation: "Remove any unneeded clusterrolebindings: kubectl delete clusterrolebinding [name]"
+      scored: false
+
+    - id: 1.6.2
+      text: "Create Pod Security Policies for your cluster (Not Scored)"
+      type: "manual"
+      remediation: "Follow the documentation and create and enforce Pod Security Policies for your cluster.
+              Additionally, you could refer the \"CIS Security Benchmark for Docker\" and follow the
+              suggested Pod Security Policies for your environment."
+      scored: false
+
+    - id: 1.6.3
+      text: "Create administrative boundaries between resources using namespaces (Not Scored)"
+      type: "manual"
+      remediation: "Follow the documentation and create namespaces for objects in your deployment as you
+              need them."
+      scored: false
+
+    - id: 1.6.4
+      text: "Create network segmentation using Network Policies (Not Scored)"
+      type: "manual"
+      remediation: "Follow the documentation and create NetworkPolicy objects as you need them."
+      scored: false
+
+    - id: 1.6.5
+      text: "Avoid using Kubernetes Secrets (Not Scored)"
+      type: "manual"
+      remediation: "Use other mechanisms such as vaults to manage your cluster secrets."
+      scored: false
+
+
+    - id: 1.6.6
+      text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Not Scored)"
+      type: "manual"
+      remediation: "Seccomp is an alpha feature currently. By default, all alpha features are disabled. So, you
+              would need to enable alpha features in the apiserver by passing \"--feature-
+              gates=AllAlpha=true\" argument.\n
+              Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS
+              parameter to \"--feature-gates=AllAlpha=true\"
+              KUBE_API_ARGS=\"--feature-gates=AllAlpha=true\""
+      scored: false
+
+    - id: 1.6.7
+      text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+      type: "manual"
+      remediation: "Follow the Kubernetes documentation and apply security contexts to your pods. For a
+              suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+              Containers."
+      scored: false
+
+    - id: 1.6.8
+      text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
+      type: "manual"
+      remediation: "Follow the Kubernetes documentation and setup image provenance."
+      scored: false

--- a/build-scripts/benchmark-conf/1.6/node.yaml
+++ b/build-scripts/benchmark-conf/1.6/node.yaml
@@ -1,0 +1,304 @@
+---
+controls:
+version: 1.6
+id: 2
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+- id: 2.1
+  text: "Kubelet"
+  checks:
+    - id: 2.1.1
+      text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--allow-privileged"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Edit the $config file on each node and set the KUBE_ALLOW_PRIV 
+              parameter to \"--allow-privileged=false\""
+      scored: true
+
+    - id: 2.1.2
+      text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--anonymous-auth"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Edit the $kubeletconf file on the master node and set the 
+              KUBELET_ARGS parameter to \"--anonymous-auth=false\""
+      scored: true
+ 
+    - id: 2.1.3
+      text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--authorization-mode"
+            compare:
+              op: nothave
+              value: "AlwaysAllow"
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the 
+              KUBELET_ARGS parameter to \"--authorization-mode=Webhook\""
+      scored: true
+   
+    - id: 2.1.4
+      text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--client-ca-file"
+            set: true 
+      remediation: "Follow the Kubernetes documentation and setup the TLS connection between 
+              the apiserver and kubelets. Then, edit the $kubeletconf file on each node 
+              and set the KUBELET_ARGS parameter to \"--client-ca-file=<path/to/client-ca-file>\""
+      scored: true
+
+    - id: 2.1.5
+      text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--read-only-port"
+            compare:
+              op: eq
+              value: 0
+            set: true 
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--read-only-port=0\""
+      scored: true
+ 
+    - id: 2.1.6
+      text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--streaming-connection-idle-timeout"
+            compare:
+              op: gt
+              value: 0
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--streaming-connection-idle-timeout=<appropriate-timeout-value>\""
+      scored: true
+
+    - id: 2.1.7
+      text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--protect-kernel-defaults"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--protect-kernel-defaults=true\""
+      scored: true
+
+    - id: 2.1.8
+      text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--make-iptables-util-chains"
+            compare:
+              op: eq
+              value: true
+            set: true
+          - flag: "--make-iptables-util-chains"
+            set: false
+      remediation: "Edit the $kubeletconf file on each node and remove the 
+              --make-iptables-util-chains argument from the KUBELET_ARGS parameter."
+      scored: true
+
+    - id: 2.1.9
+      text: "Ensure that the --keep-terminated-pod-volumes argument is set to false (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--keep-terminated-pod-volumes"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--keep-terminated-pod-volumes=false\""
+      scored: true
+
+    - id: 2.1.10
+      text: "Ensure that the --hostname-override argument is not set (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--hostname-override"
+            set: false
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_HOSTNAME 
+              parameter to \"\""
+      scored: true
+
+    - id: 2.1.11
+      text: "Ensure that the --event-qps argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--event-qps"
+            compare:
+              op: eq
+              value: 0
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--event-qps=0\""
+      scored: true
+
+    - id: 2.1.12
+      text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--tls-cert-file"
+            set: true
+          - flag: "--tls-private-key-file"
+            set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection on the Kubelet. 
+              Then, edit the $kubeletconf file on the master node and set the KUBELET_ARGS 
+              parameter to include \"--tls-cert-file=<path/to/tls-certificate-file>\" and 
+              \"--tls-private-key-file=<path/to/tls-key-file>\""
+      scored: true
+
+    - id: 2.1.13
+      text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--cadvisor-port"
+            compare:
+              op: eq
+              value: 0
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS parameter 
+              to \"--cadvisor-port=0\""
+      scored: true
+
+- id: 2.2
+  text: "Configuration Files"
+  checks:
+    - id: 2.2.1
+      text: "Ensure that the config file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $config; then stat -c %a $config; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chmod 644 $config"
+      scored: true
+
+    - id: 2.2.2
+      text: "Ensure that the config file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $config; then stat -c %U:%G $config; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: root:root
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chown root:root $config"
+      scored: true
+
+    - id: 2.2.3
+      text: "Ensure that the kubelet file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: 644
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chmod 644 $kubeletconf"
+      scored: true
+
+    - id: 2.2.4
+      text: "Ensure that the kubelet file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chown root:root $kubeletconf"
+      scored: true
+
+    - id: 2.2.5
+      text: "Ensure that the proxy file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %a $proxyconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chmod 644 $proxyconf"
+      scored: true
+
+    - id: 2.2.6
+      text: "Ensure that the proxy file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %U:%G $proxyconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chown root:root $proxyconf"
+      scored: true

--- a/build-scripts/benchmark-conf/1.7/master.yaml
+++ b/build-scripts/benchmark-conf/1.7/master.yaml
@@ -1,0 +1,1028 @@
+---
+controls:
+version: 1.7
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+- id: 1.1
+  text: "API Server"
+  checks:
+    - id: 1.1.1
+      text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "allow-privileged"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set 
+              the KUBE_ALLOW_PRIV parameter to \"--allow-privileged=false\""
+      scored: true
+
+    - id: 1.1.2
+      text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--anonymous-auth"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set 
+              the KUBE_API_ARGS parameter to \"--anonymous-auth=false\""
+      scored: true
+
+    - id: 1.1.3
+      text: "Ensure that the --basic-auth-file argument is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--basic-auth-file"
+          set: false
+      remediation: "Follow the documentation and configure alternate mechanisms for 
+              authentication. Then, edit the $apiserverconf file on the master 
+              node and remove the \"--basic-auth-file=<filename>\" argument from the 
+              KUBE_API_ARGS parameter."
+      scored: true
+
+    - id: 1.1.4
+      text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag:  "--insecure-allow-any-token"
+          set: false
+      remediation: "Edit the $apiserverconf file on the master node and remove 
+              the --insecure-allow-any-token argument from the KUBE_API_ARGS parameter."
+      scored: true
+
+    - id: 1.1.5
+      text: "Ensure that the --kubelet-https argument is set to true (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests: 
+        bin_op: or
+        test_items:
+        - flag: "--kubelet-https"
+          compare:
+            op: eq
+            value: true
+          set: true
+        - flag: "--kubelet-https"
+          set: false
+      remediation: "Edit the $apiserverconf file on the master node and remove 
+              the --kubelet-https argument from the KUBE_API_ARGS parameter."
+      scored: true
+
+    - id: 1.1.6
+      text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--insecure-bind-address"
+          set: false
+      remediation: "Edit the $apiserverconf file on the master node and remove 
+              the --insecure-bind-address argument from the KUBE_API_ADDRESS parameter."
+      scored: true
+
+    - id: 1.1.7
+      text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--insecure-port"
+          compare:
+            op: eq
+            value: 0
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set
+              --insecure-port=0 in the KUBE_API_PORT parameter."
+      scored: true
+
+    - id: 1.1.8
+      text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests: 
+        bin_op: or
+        test_items:
+          - flag:  "--secure-port"
+            compare:
+              op: gt
+              value: 0
+            set: true
+          - flag: "--secure-port"
+            set: false
+      remediation: "Edit the $apiserverconf file on the master node and either 
+              remove the --secure-port argument from the KUBE_API_ARGS parameter or set 
+              it to a different desired port."
+      scored: true
+
+    - id: 1.1.9
+      text: "Ensure that the --profiling argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--profiling"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--profiling=false\""
+      scored: true
+
+    - id: 1.1.10
+      text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--repair-malformed-updates"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--repair-malformed-updates=false\""
+      scored: true
+
+    - id: 1.1.11
+      text: "Ensure that the admission control policy is not set to AlwaysAdmit (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: nothave
+            value: AlwaysAdmit 
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to a value that does not include AlwaysAdmit"
+      scored: true
+ 
+    - id: 1.1.12
+      text: "Ensure that the admission control policy is set to AlwaysPullImages (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "AlwaysPullImages"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=...,AlwaysPullImages,...\""
+      scored: true
+ 
+    - id: 1.1.13
+      text: "Ensure that the admission control policy is set to DenyEscalatingExec (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "DenyEscalatingExec"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=...,DenyEscalatingExec,...\""
+      scored: true
+
+    - id: 1.1.14
+      text: "Ensure that the admission control policy is set to SecurityContextDeny (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "SecurityContextDeny"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=...,SecurityContextDeny,...\""
+      scored: true
+
+    - id: 1.1.15
+      text: "Ensure that the admission control policy is set to NamespaceLifecycle (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "admission-control"
+          compare:
+            op: has
+            value: "NamespaceLifecycle"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admission-control=NamespaceLifecycle,...\""
+      scored: true
+
+    - id: 1.1.16
+      text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-path"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-path=<filename>\""
+      scored: true
+
+    - id: 1.1.17
+      text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-maxage"
+          compare:
+            op: gte
+            value: 30
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-maxage=30\""
+      scored: true
+
+    - id: 1.1.18
+      text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-maxbackup"
+          compare:
+            op: gte
+            value: 10
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-maxbackup=10\""
+      scored: true
+
+    - id: 1.1.19
+      text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--audit-log-maxsize"
+          compare:
+            op: gte
+            value: 100
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--audit-log-maxsize=100\""
+      scored: true
+
+    - id: 1.1.20
+      text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--authorization-mode"
+          compare:
+            op: nothave
+            value: "AlwaysAllow"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to values other than \"--authorization-mode=AlwaysAllow\""
+      scored: true
+
+    - id: 1.1.21
+      text: "Ensure that the --token-auth-file parameter is not set (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--token-auth-file"
+          set: false
+      remediation: "Follow the documentation and configure alternate mechanisms for authentication. 
+              Then, edit the $apiserverconf file on the master node and remove the 
+              \"--tokenauth-file=<filename>\" argument from the KUBE_API_ARGS parameter."
+      scored: true
+ 
+    - id: 1.1.22
+      text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--kubelet-certificate-authority"
+          set: true
+      remediation: "Follow the Kubernetes documentation and setup the TLS connection between 
+              the apiserver and kubelets. Then, edit the $apiserverconf file on the 
+              master node and set the KUBE_API_ARGS parameter to 
+              \"--kubelet-certificate-authority=<ca-string>\""
+      scored: true
+
+    - id: 1.1.23
+      text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        bin_op: and
+        test_items:
+        - flag: "--kubelet-client-certificate"
+          set: true
+        - flag: "--kubelet-client-key"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver 
+              and kubelets. Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to \"--kubelet-clientcertificate=<path/to/client-certificate-file>\" 
+              and \"--kubelet-clientkey=<path/to/client-key-file>\""
+      scored: true
+
+    - id: 1.1.24
+      text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--service-account-lookup"
+          compare:
+            op: eq
+            value: true
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS parameter 
+              to \"--service-account-lookup=true\""
+      scored: true
+ 
+    - id: 1.1.25
+      text: "Ensure that the admission control policy is set to PodSecurityPolicy (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "PodSecurityPolicy"
+          set: true
+      remediation: "Follow the documentation and create Pod Security Policy objects as per your environment. 
+              Then, edit the $apiserverconf file on the master node and set the KUBE_ADMISSION_CONTROL 
+              parameter to \"--admission-control=...,PodSecurityPolicy,...\""
+      scored: true
+
+    - id: 1.1.26
+      text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--service-account-key-file"
+          set: true
+      remediation: "Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS 
+              parameter to \"--service-account-key-file=<filename>\""
+      scored: true
+
+    - id: 1.1.27
+      text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Scored"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        bin_op: and
+        test_items:
+        - flag: "--etcd-certfile"
+          set: true
+        - flag: "--etcd-keyfile"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver 
+              and etcd. Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to include \"--etcd-certfile=<path/to/clientcertificate-file>\" 
+              and \"--etcd-keyfile=<path/to/client-key-file>\""
+      scored: true
+ 
+    - id: 1.1.28
+      text: "Ensure that the admission control policy is set to ServiceAccount (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "ServiceAccount"
+          set: true
+      remediation: "Follow the documentation and create ServiceAccount objects as per your environment. 
+              Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_ADMISSION_CONTROL parameter to \"--admissioncontrol=...,ServiceAccount,...\""
+      scored: true
+
+    - id: 1.1.29
+      text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        bin_op: and
+        test_items:
+        - flag: "--tls-cert-file"
+          set: true
+        - flag: "--tls-private-key-file"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. 
+              Then, edit the $apiserverconf file on the master node and set the KUBE_API_ARGS parameter to 
+              include \"--tls-cert-file=<path/to/tls-certificatefile>\" and 
+              \"--tls-private-key-file=<path/to/tls-key-file>\""
+      scored: true
+
+    - id: 1.1.30
+      text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--client-ca-file"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection on the apiserver. 
+              Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to include \"--client-ca-file=<path/to/client-ca-file>\""
+      scored: true
+
+    - id: 1.1.31
+      text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--etcd-cafile"
+          set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection between the apiserver 
+              and etcd. Then, edit the $apiserverconf file on the master node and set the 
+              KUBE_API_ARGS parameter to include \"--etcd-cafile=<path/to/ca-file>\""
+      scored: true
+
+    - id: 1.1.32
+      text: "Ensure that the --authorization-mode argument is set to Node (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--authorization-mode"
+          compare:
+            op: has
+            value: "Node"
+          set: true
+      remediation: "Edit the /etc/kubernetes/apiserver file on the master node and set the KUBE_API_ARGS
+              parameter to a value to include --authorization-mode=Node. One such example could be
+              as below:\n
+              KUBE_API_ARGS=\"--authorization-mode=Node,RBAC\""
+      scored: true
+
+    - id: 1.1.33
+      text: "Ensure that the admission control policy is set to NodeRestriction (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--admission-control"
+          compare:
+            op: has
+            value: "NodeRestriction"
+          set: true
+      remediation: "Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+              Then, edit the /etc/kubernetes/apiserver file on the master node and set the
+              KUBE_ADMISSION_CONTROL parameter to \"--admissioncontrol=...,NodeRestriction,...\""
+      scored: true
+
+    - id: 1.1.34
+      text: "1.1.34 Ensure that the --experimental-encryption-provider-config argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--experimental-encryption-provider-config"
+          set: true
+      remediation: "Follow the Kubernetes documentation and configure a EncryptionConfig file. Then, edit
+              the /etc/kubernetes/apiserver file on the master node and set the KUBE_API_ARGS
+              parameter to \"--experimental-encryption-provider-config=</path/to/EncryptionConfig/File>\""
+      scored: true
+
+    - id: 1.1.35
+      text: "Ensure that the encryption provider is set to aescbc (Scored)"
+      audit: "ps -ef | grep $apiserverbin | grep -v grep"
+      type: "manual"
+      remediation: "Follow the Kubernetes documentation and configure a EncryptionConfig file. In this file,
+              choose aescbc as the encryption provider"
+      scored: true
+
+- id: 1.2
+  text: "Scheduler"
+  checks:
+    - id: 1.2.1
+      text: "Ensure that the --profiling argument is set to false (Scored)"
+      audit: "ps -ef | grep $schedulerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--profiling"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $schedulerconf file on the master node and set the KUBE_SCHEDULER_ARGS 
+              parameter to \"--profiling=false\""
+      scored: true
+
+- id: 1.3
+  text: "Controller Manager"
+  checks:
+    - id: 1.3.1
+      text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--terminated-pod-gc-threshold"
+            set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to \"--terminated-pod-gcthreshold=<appropriate-number>\""
+      scored: true
+ 
+    - id: 1.3.2
+      text: "Ensure that the --profiling argument is set to false (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--profiling"
+          compare:
+            op: eq
+            value: false
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to \"--profiling=false\""
+      scored: true
+ 
+    - id: 1.3.3
+      text: "Ensure that the --use-service-account-credentials argument is set"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--use-service-account-credentials"
+          compare:
+            op: eq
+            value: true
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to --use-service-account-credentials=true"
+      scored: true
+
+    - id: 1.3.4
+      text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--service-account-private-key-file"
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to --service-account-private-keyfile=<filename>"
+      scored: true
+
+    - id: 1.3.5
+      text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "--root-ca-file"
+          set: true
+      remediation: "Edit the $controllermanagerconf file on the master node and set the 
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to include --root-ca-file=<file>"
+      scored: true
+
+    - id: 1.3.6
+      text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+      type: "manual"
+      remediation: "Edit the /etc/kubernetes/controller-manager file on the master node and set the
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to a value to include 
+              \"--feature-gates=RotateKubeletServerCertificate=true\""
+      scored: false
+
+    - id: 1.3.7
+      text: " Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
+      audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+      tests:
+        test_items:
+        - flag: "RotateKubeletServerCertificate"
+          compare:
+            op: eq
+            value: true
+          set: true
+      remediation: "Edit the /etc/kubernetes/controller-manager file on the master node and set the
+              KUBE_CONTROLLER_MANAGER_ARGS parameter to a value to include 
+              \"--feature-gates=RotateKubeletServerCertificate=true\""
+      scored: true
+ 
+- id: 1.4
+  text: "Configure Files"
+  checks:
+    - id: 1.4.1
+      text: "Ensure that the apiserver file permissions are set to 644 or more restrictive (Scored)"
+      # audit: "/bin/bash -c 'if test -e $apiserverconf; then stat -c %a $apiserverconf; fi'"
+      audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %a $apiserverconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $apiserverconf"
+      scored: true
+
+    - id: 1.4.2
+      text: "Ensure that the apiserver file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $apiserverconf"
+      scored: true
+
+    - id: 1.4.3
+      text: "Ensure that the config file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %a $kubernetesconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $kubernetesconf"
+      scored: true
+
+    - id: 1.4.4
+      text: "Ensure that the config file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %U:%G $kubernetesconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $kubernetesconf"
+      scored: true
+
+    - id: 1.4.5
+      text: "Ensure that the scheduler file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $schedulerconf"
+      scored: true
+
+    - id: 1.4.6
+      text: "Ensure that the scheduler file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: "root:root"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $schedulerconf"
+      scored: true
+
+    - id: 1.4.7
+      text: "Ensure that the etcd.conf file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $etcdconf"
+      scored: true
+
+    - id: 1.4.8
+      text: "Ensure that the etcd.conf file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $etcdconf"
+      scored: true
+
+    - id: 1.4.9
+      text: "Ensure that the flanneld file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $flanneldconf; then stat -c %a $flanneldconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chmod 644 $flanneldconf"
+      scored: true
+
+    - id: 1.4.10
+      text: "Ensure that the flanneld file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $flanneldconf; then stat -c %U:%G $flanneldconf; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+      remediation: "Run the below command (based on the file location on your system) on the master node. 
+              \nFor example, chown root:root $flanneldconf"
+      scored: true
+      
+    - id: 1.4.11
+      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %a"
+      tests:
+        test_items:
+        - flag: "700"
+          compare:
+            op: eq
+            value: "700"
+          set: true
+      remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+              from the below command:\n
+              ps -ef | grep $etcdbin\n
+              Run the below command (based on the etcd data directory found above). For example,\n
+              chmod 700 /var/lib/etcd/default.etcd"
+      scored: true
+
+    - id: 1.4.12
+      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %U:%G"
+      tests:
+        test_items:
+        - flag: "etcd:etcd"
+          set: true
+      remediation: "On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+              from the below command:\n
+                      ps -ef | grep etcd\n
+              Run the below command (based on the etcd data directory found above). For example,\n
+                      chown etcd:etcd /var/lib/etcd/default.etcd"
+      scored: true
+
+- id: 1.5
+  text: "etcd"
+  checks:
+    - id: 1.5.1
+      text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--cert-file"
+            set: true
+          - flag:  "--key-file"
+            set: true
+      remediation: "Follow the etcd service documentation and configure TLS encryption."
+      scored: true
+
+    - id: 1.5.2
+      text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--client-cert-auth"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Edit the etcd envrironment file (for example, $etcdconf) on the 
+              etcd server node and set the ETCD_CLIENT_CERT_AUTH parameter to \"true\". 
+              Edit the etcd startup file (for example, /etc/systemd/system/multiuser.target.wants/etcd.service) 
+              and configure the startup parameter for --clientcert-auth and set it to \"${ETCD_CLIENT_CERT_AUTH}\""
+      scored: true
+
+    - id: 1.5.3
+      text: "Ensure that the --auto-tls argument is not set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--auto-tls"
+            set: false
+          - flag: "--auto-tls"
+            compare:
+              op: neq
+              value: true
+      remediation: "Edit the etcd environment file (for example, $etcdconf) on the etcd server 
+              node and comment out the ETCD_AUTO_TLS parameter. Edit the etcd startup file (for example, 
+              /etc/systemd/system/multiuser.target.wants/etcd.service) and remove the startup parameter 
+              for --auto-tls."
+      scored: true
+
+    - id: 1.5.4
+      text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--peer-cert-file"
+            set: true
+          - flag: "--peer-key-file"
+            set: true
+      remediation: "Note: This recommendation is applicable only for etcd clusters. If you are using only 
+              one etcd server in your environment then this recommendation is not applicable. 
+              Follow the etcd service documentation and configure peer TLS encryption as appropriate for 
+              your etcd cluster."
+      scored: true
+
+    - id: 1.5.5
+      text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--peer-client-cert-auth"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Note: This recommendation is applicable only for etcd clusters. If you are using only 
+              one etcd server in your environment then this recommendation is not applicable.
+              Edit the etcd environment file (for example, $etcdconf) on the etcd server node 
+              and set the ETCD_PEER_CLIENT_CERT_AUTH parameter to \"true\". Edit the etcd startup file 
+              (for example, /etc/systemd/system/multiuser.target.wants/etcd.service) and configure the 
+              startup parameter for --peer-client-cert-auth and set it to \"${ETCD_PEER_CLIENT_CERT_AUTH}\""
+      scored: true
+
+    - id: 1.5.6
+      text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--peer-auto-tls"
+            set: false
+          - flag: "--peer-auto-tls"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Note: This recommendation is applicable only for etcd clusters. 
+              If you are using only one etcd server in your environment then this recommendation is 
+              not applicable. Edit the etcd environment file (for example, $etcdconf) 
+              on the etcd server node and comment out the ETCD_PEER_AUTO_TLS parameter. 
+              Edit the etcd startup file (for example, /etc/systemd/system/multiuser.target.wants/etcd.service) 
+              and remove the startup parameter for --peer-auto-tls."
+      scored: true
+
+    - id: 1.5.7
+      text: "Ensure that the --wal-dir argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--wal-dir"
+            set: true
+      remediation: "Edit the etcd environment file (for example, $etcdconf) on the etcd server node 
+              and set the ETCD_WAL_DIR parameter as appropriate. Edit the etcd startup file (for example, 
+              /etc/systemd/system/multiuser.target.wants/etcd.service) and configure the startup parameter for 
+              --wal-dir and set it to \"${ETCD_WAL_DIR}\""
+      scored: true
+
+    - id: 1.5.8
+      text: "Ensure that the --max-wals argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--max-wals"
+            compare:
+              op: eq
+              value: 0
+            set: true
+      remediation: "Edit the etcd environment file (for example, $etcdconf) on the etcd server node 
+              and set the ETCD_MAX_WALS parameter to 0. Edit the etcd startup file (for example, 
+              /etc/systemd/system/multiuser.target.wants/etcd.service) and configure the startup parameter 
+              for --max-wals and set it to \"${ETCD_MAX_WALS}\"."
+      scored: true
+
+    - id: 1.5.9
+      text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
+      audit: "ps -ef | grep $etcdbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--trusted-ca-file"
+            set: true
+      remediation: "Follow the etcd documentation and create a dedicated certificate authority setup for the 
+              etcd service."
+      scored: false 
+
+- id: 1.6
+  text: "General Security Primitives"
+  checks:
+    - id: 1.6.1
+      text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
+      type: "manual"
+      remediation: "Remove any unneeded clusterrolebindings: kubectl delete clusterrolebinding [name]"
+      scored: false
+
+    - id: 1.6.2
+      text: "Create Pod Security Policies for your cluster (Not Scored)"
+      type: "manual"
+      remediation: "Follow the documentation and create and enforce Pod Security Policies for your cluster.
+              Additionally, you could refer the \"CIS Security Benchmark for Docker\" and follow the
+              suggested Pod Security Policies for your environment."
+      scored: false
+
+    - id: 1.6.3
+      text: "Create administrative boundaries between resources using namespaces (Not Scored)"
+      type: "manual"
+      remediation: "Follow the documentation and create namespaces for objects in your deployment as you
+              need them."
+      scored: false
+
+    - id: 1.6.4
+      text: "Create network segmentation using Network Policies (Not Scored)"
+      type: "manual"
+      remediation: "Follow the documentation and create NetworkPolicy objects as you need them."
+      scored: false
+
+    - id: 1.6.5
+      text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Not Scored)"
+      type: "manual"
+      remediation: "Seccomp is an alpha feature currently. By default, all alpha features are disabled. So, you
+              would need to enable alpha features in the apiserver by passing \"--feature-
+              gates=AllAlpha=true\" argument.\n
+              Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS
+              parameter to \"--feature-gates=AllAlpha=true\"
+              KUBE_API_ARGS=\"--feature-gates=AllAlpha=true\""
+      scored: false
+
+    - id: 1.6.6
+      text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+      type: "manual"
+      remediation: "Follow the Kubernetes documentation and apply security contexts to your pods. For a
+              suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+              Containers."
+      scored: false
+
+    - id: 1.6.7
+      text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
+      type: "manual"
+      remediation: "Follow the Kubernetes documentation and setup image provenance."
+      scored: false
+
+    - id: 1.6.8
+      text: "Configure Network policies as appropriate (Not Scored)"
+      type: "manual"
+      remediation: "Follow the Kubernetes documentation and setup network policies as appropriate."
+      scored: false
+

--- a/build-scripts/benchmark-conf/1.7/node.yaml
+++ b/build-scripts/benchmark-conf/1.7/node.yaml
@@ -1,0 +1,370 @@
+---
+controls:
+version: 1.7
+id: 2
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+- id: 2.1
+  text: "Kubelet"
+  checks:
+    - id: 2.1.1
+      text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--allow-privileged"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBE_ALLOW_PRIV 
+              parameter to \"--allow-privileged=false\""
+      scored: true
+
+    - id: 2.1.2
+      text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--anonymous-auth"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Edit the $kubeletconf file on the master node and set the 
+              KUBELET_ARGS parameter to \"--anonymous-auth=false\""
+      scored: true
+ 
+    - id: 2.1.3
+      text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--authorization-mode"
+            compare:
+              op: nothave
+              value: "AlwaysAllow"
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the 
+              KUBELET_ARGS parameter to \"--authorization-mode=Webhook\""
+      scored: true
+   
+    - id: 2.1.4
+      text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--client-ca-file"
+            set: true 
+      remediation: "Follow the Kubernetes documentation and setup the TLS connection between 
+              the apiserver and kubelets. Then, edit the $kubeletconf file on each node 
+              and set the KUBELET_ARGS parameter to \"--client-ca-file=<path/to/client-ca-file>\""
+      scored: true
+
+    - id: 2.1.5
+      text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--read-only-port"
+            compare:
+              op: eq
+              value: 0
+            set: true 
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--read-only-port=0\""
+      scored: true
+ 
+    - id: 2.1.6
+      text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--streaming-connection-idle-timeout"
+            compare:
+              op: noteq
+              value: 0
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--streaming-connection-idle-timeout=<appropriate-timeout-value>\""
+      scored: true
+
+    - id: 2.1.7
+      text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--protect-kernel-defaults"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--protect-kernel-defaults=true\""
+      scored: true
+
+    - id: 2.1.8
+      text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "--make-iptables-util-chains"
+            compare:
+              op: eq
+              value: true
+            set: true
+          - flag: "--make-iptables-util-chains"
+            set: false
+      remediation: "Edit the $kubeletconf file on each node and remove the 
+              --make-iptables-util-chains argument from the KUBELET_ARGS parameter."
+      scored: true
+
+    - id: 2.1.9
+      text: "Ensure that the --keep-terminated-pod-volumes argument is set to false (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--keep-terminated-pod-volumes"
+            compare:
+              op: eq
+              value: false
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--keep-terminated-pod-volumes=false\""
+      scored: true
+
+    - id: 2.1.10
+      text: "Ensure that the --hostname-override argument is not set (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--hostname-override"
+            set: false
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_HOSTNAME 
+              parameter to \"\""
+      scored: true
+
+    - id: 2.1.11
+      text: "Ensure that the --event-qps argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--event-qps"
+            compare:
+              op: eq
+              value: 0
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS 
+              parameter to \"--event-qps=0\""
+      scored: true
+
+    - id: 2.1.12
+      text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--tls-cert-file"
+            set: true
+          - flag: "--tls-private-key-file"
+            set: true
+      remediation: "Follow the Kubernetes documentation and set up the TLS connection on the Kubelet. 
+              Then, edit the $kubeletconf file on the master node and set the KUBELET_ARGS 
+              parameter to include \"--tls-cert-file=<path/to/tls-certificate-file>\" and 
+              \"--tls-private-key-file=<path/to/tls-key-file>\""
+      scored: true
+
+    - id: 2.1.13
+      text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "--cadvisor-port"
+            compare:
+              op: eq
+              value: 0
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS parameter 
+              to \"--cadvisor-port=0\""
+      scored: true
+
+    - id: 2.1.14
+      text: "Ensure that the RotateKubeletClientCertificate argument is set to true"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "RotateKubeletClientCertificate"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS parameter
+              to a value to include \"--feature-gates=RotateKubeletClientCertificate=true\"."
+      scored: true
+
+    - id: 2.1.15
+      text: "Ensure that the RotateKubeletServerCertificate argument is set to true"
+      audit: "ps -ef | grep $kubeletbin | grep -v grep"
+      tests:
+        test_items:
+          - flag: "RotateKubeletServerCertificate"
+            compare:
+              op: eq
+              value: true
+            set: true
+      remediation: "Edit the $kubeletconf file on each node and set the KUBELET_ARGS parameter
+              to a value to include \"--feature-gates=RotateKubeletServerCertificate=true\"."
+      scored: true
+
+- id: 2.2
+  text: "Configuration Files"
+  checks:
+    - id: 2.2.1
+      text: "Ensure that the config file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %a $kubernetesconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chmod 644 $kubernetesconf"
+      scored: true
+
+    - id: 2.2.2
+      text: "Ensure that the config file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubernetesconf; then stat -c %U:%G $kubernetesconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: root:root
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chown root:root $kubernetesconf"
+      scored: true
+
+    - id: 2.2.3
+      text: "Ensure that the kubelet file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: 644
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chmod 644 $kubeletconf"
+      scored: true
+
+    - id: 2.2.4
+      text: "Ensure that the kubelet file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chown root:root $kubeletconf"
+      scored: true
+
+    - id: 2.2.5
+      text: "Ensure that the proxy file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %a $proxyconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chmod 644 $proxyconf"
+      scored: true
+
+    - id: 2.2.6
+      text: "Ensure that the proxy file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %U:%G $proxyconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            set: true
+      remediation: "Run the below command (based on the file location on your system) on the each worker node. 
+              \nFor example, chown root:root $proxyconf"
+      scored: true
+
+    - id: 2.2.7
+      text: "Ensure that the certificate authorities file permissions are set to
+              644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $ca-file; then stat -c %a $ca-file; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: "Run the following command to modify the file permissions of the --client-ca-file
+              \nchmod 644 <filename>"
+      scored: true
+
+    - id: 2.2.8
+      text: "Ensure that the client certificate authorities file ownership is set to root:root"
+      audit: "/bin/sh -c 'if test -e $ca-file; then stat -c %U:%G $ca-file; fi'"
+      tests:
+        test_items:
+          - flag: "notexist:notexist"
+            set: true
+      remediation: "Run the following command to modify the ownership of the --client-ca-file.
+              \nchown root:root <filename>"
+      scored: true

--- a/build-scripts/benchmark-conf/1.8/master.yaml
+++ b/build-scripts/benchmark-conf/1.8/master.yaml
@@ -1,0 +1,1325 @@
+---
+controls:
+version: 1.8
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+- id: 1.1
+  text: "API Server"
+  checks:
+  - id: 1.1.1
+    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--anonymous-auth"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: | 
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --anonymous-auth=false
+
+    scored: true
+
+  - id: 1.1.2
+    text: "Ensure that the --basic-auth-file argument is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--basic-auth-file"
+        set: false
+    remediation: |
+      Follow the documentation and configure alternate mechanisms for authentication. Then,
+      edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --basic-auth-file=<filename>
+      parameter.
+    scored: true
+
+  - id: 1.1.3
+    text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag:  "--insecure-allow-any-token"
+        set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --insecure-allow-any-token
+      parameter.
+    scored: true
+
+  - id: 1.1.4
+    text: "Ensure that the --kubelet-https argument is set to true (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests: 
+      bin_op: or
+      test_items:
+      - flag: "--kubelet-https"
+        compare:
+          op: eq
+          value: true
+        set: true
+      - flag: "--kubelet-https"
+        set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --kubelet-https parameter.
+    scored: true
+
+  - id: 1.1.5
+    text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--insecure-bind-address"
+        set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --insecure-bind-address
+      parameter.
+    scored: true
+
+  - id: 1.1.6
+    text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--insecure-port"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      apiserver.yaml on the master node and set the below parameter.
+      --insecure-port=0
+    scored: true
+
+  - id: 1.1.7
+    text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests: 
+      bin_op: or
+      test_items:
+        - flag:  "--secure-port"
+          compare:
+            op: gt
+            value: 0
+          set: true
+        - flag: "--secure-port"
+          set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and either remove the --secure-port parameter or
+      set it to a different (non-zero) desired port.
+    scored: true
+
+  - id: 1.1.8
+    text: "Ensure that the --profiling argument is set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--profiling"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --profiling=false
+    scored: true
+
+  - id: 1.1.9
+    text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--repair-malformed-updates"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --repair-malformed-updates=false
+    scored: true
+
+  - id: 1.1.10
+    text: "Ensure that the admission control policy is not set to AlwaysAdmit (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: nothave
+          value: AlwaysAdmit 
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that does not include AlwaysAdmit.
+    scored: true
+
+  - id: 1.1.11
+    text: "Ensure that the admission control policy is set to AlwaysPullImages (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "AlwaysPullImages"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to
+      include AlwaysPullImages.
+      --admission-control=...,AlwaysPullImages,...
+    scored: true
+
+  - id: 1.1.12
+    text: "Ensure that the admission control policy is set to DenyEscalatingExec (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "DenyEscalatingExec"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes DenyEscalatingExec.
+      --admission-control=...,DenyEscalatingExec,...
+    scored: true
+
+  - id: 1.1.13
+    text: "Ensure that the admission control policy is set to SecurityContextDeny (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "SecurityContextDeny"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to
+      include SecurityContextDeny.
+      --admission-control=...,SecurityContextDeny,...
+    scored: true
+
+  - id: 1.1.14
+    text: "Ensure that the admission control policy is set to NamespaceLifecycle (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "admission-control"
+        compare:
+          op: has
+          value: "NamespaceLifecycle"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to
+      include NamespaceLifecycle.
+      --admission-control=...,NamespaceLifecycle,...
+    scored: true
+
+  - id: 1.1.15
+    text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-path"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-path parameter to a suitable
+    path and file where you would like audit logs to be written, for example:
+            --audit-log-path=/var/log/apiserver/audit.log
+    scored: true
+
+  - id: 1.1.16
+    text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-maxage"
+        compare:
+          op: gte
+          value: 30
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-maxage parameter to 30 or
+    as an appropriate number of days:
+            --audit-log-maxage=30
+    scored: true
+
+  - id: 1.1.17
+    text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-maxbackup"
+        compare:
+          op: gte
+          value: 10
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-maxbackup parameter to 10
+      or to an appropriate value.
+      --audit-log-maxbackup=10
+    scored: true
+
+  - id: 1.1.18
+    text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-maxsize"
+        compare:
+          op: gte
+          value: 100
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-maxsize parameter to an
+      appropriate size in MB. For example, to set it as 100 MB:
+      --audit-log-maxsize=100
+    scored: true
+
+  - id: 1.1.19
+    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--authorization-mode"
+        compare:
+          op: nothave
+          value: "AlwaysAllow"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --authorization-mode parameter to
+      values other than AlwaysAllow. One such example could be as below.
+      --authorization-mode=RBAC
+    scored: true
+
+  - id: 1.1.20
+    text: "Ensure that the --token-auth-file parameter is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--token-auth-file"
+        set: false
+    remediation: |
+      Follow the documentation and configure alternate mechanisms for authentication. Then,
+      edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --token-auth-file=<filename>
+      parameter.
+    scored: true
+
+  - id: 1.1.21
+    text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--kubelet-certificate-authority"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and setup the TLS connection between the apiserver
+      and kubelets. Then, edit the API server pod specification file
+      $apiserverpodspec on the master node and set the --
+      kubelet-certificate-authority parameter to the path to the cert file for the certificate
+      authority.
+      --kubelet-certificate-authority=<ca-string>
+    scored: true
+
+  - id: 1.1.22
+    text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are
+      set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      bin_op: and
+      test_items:
+      - flag: "--kubelet-client-certificate"
+        set: true
+      - flag: "--kubelet-client-key"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and kubelets. Then, edit API server pod specification file
+      $apiserverpodspec on the master node and set the
+      kubelet client certificate and key parameters as below.
+      --kubelet-client-certificate=<path/to/client-certificate-file>
+      --kubelet-client-key=<path/to/client-key-file>
+    scored: true
+
+  - id: 1.1.23
+    text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--service-account-lookup"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --service-account-lookup=true
+    scored: true
+
+  - id: 1.1.24
+    text: "Ensure that the admission control policy is set to PodSecurityPolicy (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "PodSecurityPolicy"
+        set: true
+    remediation: |
+      Follow the documentation and create Pod Security Policy objects as per your environment.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes PodSecurityPolicy :
+      --admission-control=...,PodSecurityPolicy,...
+
+      Then restart the API Server.
+    scored: true
+
+  - id: 1.1.25
+    text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--service-account-key-file"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --service-account-key-file parameter
+      to the public key file for service accounts:
+      --service-account-key-file=<filename>
+    scored: true
+
+  - id: 1.1.26
+    text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as 
+      appropriate (Scored"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      bin_op: and
+      test_items:
+      - flag: "--etcd-certfile"
+        set: true
+      - flag: "--etcd-keyfile"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and etcd. Then, edit the API server pod specification file
+      $apiserverpodspec on the master node and set the etcd
+      certificate and key file parameters.
+      --etcd-certfile=<path/to/client-certificate-file>
+      --etcd-keyfile=<path/to/client-key-file>
+    scored: true
+
+  - id: 1.1.27
+    text: "Ensure that the admission control policy is set to ServiceAccount (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "ServiceAccount"
+        set: true
+    remediation: |
+      Follow the documentation and create ServiceAccount objects as per your environment.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes ServiceAccount.
+      --admission-control=...,ServiceAccount,...
+    scored: true
+
+  - id: 1.1.28
+    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set
+    as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      bin_op: and
+      test_items:
+      - flag: "--tls-cert-file"
+        set: true
+      - flag: "--tls-private-key-file"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the TLS certificate and private key file
+      parameters.
+      --tls-cert-file=<path/to/tls-certificate-file>
+      --tls-private-key-file=<path/to/tls-key-file>
+    scored: true
+
+  - id: 1.1.29
+    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--client-ca-file"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the client certificate authority file.
+      --client-ca-file=<path/to/client-ca-file>
+    scored: true
+
+  - id: 1.1.30
+    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--etcd-cafile"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and etcd. Then, edit the API server pod specification file
+      $apiserverpodspec on the master node and set the etcd
+      certificate authority file parameter.
+      --etcd-cafile=<path/to/ca-file>
+    scored: true
+
+  - id: 1.1.31
+    text: "Ensure that the --authorization-mode argument is set to Node (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--authorization-mode"
+        compare:
+          op: has
+          value: "Node"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --authorization-mode parameter to a
+      value that includes Node.
+      --authorization-mode=Node,RBAC
+    scored: true
+
+  - id: 1.1.32
+    text: "Ensure that the admission control policy is set to NodeRestriction (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "NodeRestriction"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes NodeRestriction.
+      --admission-control=...,NodeRestriction,...
+    scored: true
+
+  - id: 1.1.33
+    text: "Ensure that the --experimental-encryption-provider-config argument is
+    set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--experimental-encryption-provider-config"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and configure a EncryptionConfig file. Then, edit
+      the API server pod specification file $apiserverpodspec
+      on the master node and set the --experimental-encryption-provider-config parameter
+      to the path of that file:
+      --experimental-encryption-provider-config=</path/to/EncryptionConfig/File>
+    scored: true
+
+  - id: 1.1.34
+    text: "Ensure that the encryption provider is set to aescbc (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and configure a EncryptionConfig file. In this file,
+      choose aescbc as the encryption provider.
+      For example,
+      kind: EncryptionConfig
+      apiVersion: v1
+      resources:
+        - resources:
+          - secrets
+            providers:
+            - aescbc:
+                keys:
+                - name: key1
+                  secret: <32-byte base64-encoded secret>
+    scored: true
+
+  - id: 1.1.35
+    text: "Ensure that the admission control policy is set to EventRateLimit (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "EventRateLimit"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set the desired limits in a configuration file.
+      Then, edit the API server pod specification file $apiserverpodspec
+      and set the below parameters.
+      --admission-control=EventRateLimit
+      --admission-control-config-file=<path/to/configuration/file>
+    scored: true
+
+  - id: 1.1.36
+    text: "Ensure that the AdvancedAuditing argument is not set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and set the desired audit policy in the
+      /etc/kubernetes/audit-policy.yaml file. Then, edit the API server pod specification file $apiserverpodspec
+      and set the below parameters.
+      --audit-policy-file=/etc/kubernetes/audit-policy.yaml
+    scored: true
+
+  - id: 1.1.37
+    text: "Ensure that the --request-timeout argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      and set the below parameter as appropriate and if needed. For example,
+      --request-timeout=300
+    scored: true
+
+- id: 1.2
+  text: "Scheduler"
+  checks:
+  - id: 1.2.1
+    text: "Ensure that the --profiling argument is set to false (Scored)"
+    audit: "ps -ef | grep $schedulerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--profiling"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Remediation:
+        Edit the Scheduler pod specification file $apiserverpodspec
+        file on the master node and set the below parameter.
+        --profiling=false
+    scored: true
+
+- id: 1.3
+  text: "Controller Manager"
+  checks:
+  - id: 1.3.1
+    text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+        - flag: "--terminated-pod-gc-threshold"
+          set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold, for example:
+      --terminated-pod-gc-threshold=10
+    scored: true
+
+  - id: 1.3.2
+    text: "Ensure that the --profiling argument is set to false (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--profiling"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --profiling=false
+    scored: true
+
+  - id: 1.3.3
+    text: "Ensure that the --use-service-account-credentials argument is set"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--use-service-account-credentials"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node to set the below parameter.
+      --use-service-account-credentials=true
+    scored: true
+
+  - id: 1.3.4
+    text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--service-account-private-key-file"
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the --service-account-private-
+      key-file parameter to the private key file for service accounts.
+      --service-account-private-key-file=<filename>
+    scored: true
+
+  - id: 1.3.5
+    text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--root-ca-file"
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the --root-ca-file parameter to
+      the certificate bundle file.
+      --root-ca-file=<path/to/file>
+    scored: true
+
+  - id: 1.3.6
+    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and apply security contexts to your pods. For a
+      suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+      Containers.
+    scored: false
+
+  - id: 1.3.7
+    text: " Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "RotateKubeletServerCertificate"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      controller-manager.yaml on the master node and set the --feature-gates parameter to
+      include RotateKubeletServerCertificate=true.
+      --feature-gates=RotateKubeletServerCertificate=true
+    scored: true
+
+- id: 1.4
+  text: "Configuration Files"
+  checks:
+  - id: 1.4.1
+    text: "Ensure that the API server pod specification file permissions are
+    set to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $apiserverpodspec; then stat -c %a $apiserverpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $apiserverpodspec
+    scored: true
+
+  - id: 1.4.2
+    text: "Ensure that the API server pod specification file ownership is set to
+    root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $apiserverpodspec; then stat -c %U:%G $apiserverpodspec; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $apiserverpodspec
+    scored: true
+
+  - id: 1.4.3
+    text: "Ensure that the controller manager pod specification file
+    permissions are set to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerpodspec; then stat -c %a $controllermanagerpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $controllermanagerpodspec
+    scored: true
+
+  - id: 1.4.4
+    text: "Ensure that the controller manager pod specification file
+    ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerpodspec; then stat -c %U:%G $controllermanagerpodspec; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $controllermanagerpodspec
+    scored: true
+
+  - id: 1.4.5
+    text: "Ensure that the scheduler pod specification file permissions are set
+    to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerpodspec; then stat -c %a $schedulerpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $schedulerpodspec
+    scored: true
+
+  - id: 1.4.6
+    text: "Ensure that the scheduler pod specification file ownership is set to
+    root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerpodspec; then stat -c %U:%G $schedulerpodspec; fi'"
+    tests:
+      test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $schedulerpodspec
+    scored: true
+
+  - id: 1.4.7
+    text: "Ensure that the etcd pod specification file permissions are set to
+    644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $etcdpodspec; then stat -c %a $etcdpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $etcdpodspec
+    scored: true
+
+  - id: 1.4.8
+    text: "Ensure that the etcd pod specification file ownership is set to
+    root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $etcdpodspec; then stat -c %U:%G $etcdpodspec; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $etcdpodspec
+    scored: true
+
+  - id: 1.4.9
+    text: "Ensure that the Container Network Interface file permissions are
+    set to 644 or more restrictive (Not Scored)"
+    audit: "stat -c %a <path/to/cni/files>"
+    type: manual
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 <path/to/cni/files>
+    scored: true
+
+  - id: 1.4.10
+    text: "Ensure that the Container Network Interface file ownership is set
+    to root:root (Not Scored)"
+    audit: "stat -c %U:%G <path/to/cni/files>"
+    type: manual
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root <path/to/cni/files>
+    scored: true
+
+  - id: 1.4.11
+    text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %a"
+    tests:
+      test_items:
+      - flag: "700"
+        compare:
+          op: eq
+          value: "700"
+        set: true
+    remediation: |
+      On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+      from the below command:
+      ps -ef | grep $etcdbin
+      Run the below command (based on the etcd data directory found above). For example,
+      chmod 700 /var/lib/etcd
+    scored: true
+
+  - id: 1.4.12
+    text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %U:%G"
+    tests:
+      test_items:
+      - flag: "etcd:etcd"
+        set: true
+    remediation: |
+      On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+      from the below command:
+      ps -ef | grep $etcdbin
+      Run the below command (based on the etcd data directory found above). For example,
+      chown etcd:etcd /var/lib/etcd
+    scored: true
+
+  - id: 1.4.13
+    text: "Ensure that the admin.conf file permissions are set to 644 or
+    more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %a /etc/kubernetes/admin.conf; fi'"
+    tests:
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 /etc/kubernetes/admin.conf
+    scored: true
+
+  - id: 1.4.14
+    text: "Ensure that the admin.conf file ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root /etc/kubernetes/admin.conf
+    scored: true
+
+  - id: 1.4.15
+    text: "Ensure that the scheduler.conf file permissions are set to 644 or
+    more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerconf then stat -c %a $schedulerconf; fi'"
+    tests:
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $schedulerconf
+    scored: true
+
+  - id: 1.4.16
+    text: "Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $schedulerconf
+    scored: true
+
+  - id: 1.4.17
+    text: "Ensure that the controller-manager.conf file permissions are set
+    to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerconf then stat -c %a $controllermanagerconf; fi'"
+    tests:
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $controllermanagerconf
+    scored: true
+
+  - id: 1.4.18
+    text: "Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $controllermanagerconf
+    scored: true
+
+- id: 1.5
+  text: "etcd"
+  checks:
+  - id: 1.5.1
+    text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--cert-file"
+        set: true
+      - flag:  "--key-file"
+        set: true
+    remediation: |
+      Follow the etcd service documentation and configure TLS encryption.
+      Then, edit the etcd pod specification file $etcdpodspec on the
+      master node and set the below parameters.
+      --ca-file=</path/to/ca-file>
+      --key-file=</path/to/key-file>
+    scored: true
+
+  - id: 1.5.2
+    text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--client-cert-auth"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --client-cert-auth="true"
+    scored: true
+
+  - id: 1.5.3
+    text: "Ensure that the --auto-tls argument is not set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "--auto-tls"
+        set: false
+      - flag: "--auto-tls"
+        compare:
+          op: neq
+          value: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and either remove the --auto-tls parameter or set it to false.
+        --auto-tls=false
+    scored: true
+
+  - id: 1.5.4
+    text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set
+    as appropriate (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--peer-cert-file"
+        set: true
+      - flag: "--peer-key-file"
+        set: true
+    remediation: |
+      Follow the etcd service documentation and configure peer TLS encryption as appropriate
+      for your etcd cluster. Then, edit the etcd pod specification file $etcdpodspec on the
+      master node and set the below parameters.
+      --peer-client-file=</path/to/peer-cert-file>
+      --peer-key-file=</path/to/peer-key-file>
+    scored: true
+
+  - id: 1.5.5
+    text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--peer-client-cert-auth"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --peer-client-cert-auth=true
+    scored: true
+
+  - id: 1.5.6
+    text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "--peer-auto-tls"
+        set: false
+      - flag: "--peer-auto-tls"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and either remove the --peer-auto-tls parameter or set it to false.
+      --peer-auto-tls=false
+    scored: true
+
+  - id: 1.5.7
+    text: "Ensure that the --wal-dir argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--wal-dir"
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --wal-dir=</path/to/log/dir>
+    scored: true
+
+  - id: 1.5.8
+    text: "Ensure that the --max-wals argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--max-wals"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --max-wals=0
+    scored: true
+
+  - id: 1.5.9
+    text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--trusted-ca-file"
+        set: true
+    remediation: |
+      Follow the etcd documentation and create a dedicated certificate authority setup for the
+      etcd service.
+      Then, edit the etcd pod specification file $etcdpodspec on the
+      master node and set the below parameter.
+      --trusted-ca-file=</path/to/ca-file>
+    scored: false 
+
+- id: 1.6
+  text: "General Security Primitives"
+  checks:
+  - id: 1.6.1
+    text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
+    type: "manual"
+    remediation: |
+      Remove any unneeded clusterrolebindings :
+      kubectl delete clusterrolebinding [name]
+    scored: false
+
+  - id: 1.6.2
+    text: "Create Pod Security Policies for your cluster (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the documentation and create and enforce Pod Security Policies for your cluster.
+      Additionally, you could refer the "CIS Security Benchmark for Docker" and follow the
+      suggested Pod Security Policies for your environment.
+    scored: false
+
+  - id: 1.6.3
+    text: "Create administrative boundaries between resources using namespaces (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the documentation and create namespaces for objects in your deployment as you
+      need them.
+    scored: false
+
+  - id: 1.6.4
+    text: "Create network segmentation using Network Policies (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the documentation and create NetworkPolicy objects as you need them.
+    scored: false
+
+  - id: 1.6.5
+    text: "Ensure that the seccomp profile is set to docker/default in your pod 
+    definitions (Not Scored)"
+    type: "manual"
+    remediation: |
+      Seccomp is an alpha feature currently. By default, all alpha features are disabled. So, you
+      would need to enable alpha features in the apiserver by passing "--feature-
+      gates=AllAlpha=true" argument.
+      Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS
+      parameter to "--feature-gates=AllAlpha=true"
+      KUBE_API_ARGS="--feature-gates=AllAlpha=true"
+      Based on your system, restart the kube-apiserver service. For example:
+      systemctl restart kube-apiserver.service
+      Use annotations to enable the docker/default seccomp profile in your pod definitions. An
+      example is as below:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: trustworthy-pod
+        annotations:
+          seccomp.security.alpha.kubernetes.io/pod: docker/default
+      spec:
+        containers:
+          - name: trustworthy-container
+            image: sotrustworthy:latest
+    scored: false
+
+  - id: 1.6.6
+    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and apply security contexts to your pods. For a
+      suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+      Containers.
+    scored: false
+
+  - id: 1.6.7
+    text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and setup image provenance.
+    scored: false
+
+  - id: 1.6.8
+    text: "Configure Network policies as appropriate (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and setup network policies as appropriate.
+      For example, you could create a "default" isolation policy for a Namespace by creating a
+      NetworkPolicy that selects all pods but does not allow any traffic:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: default-deny
+      spec:
+        podSelector:
+    scored: false
+
+  - id: 1.6.9
+    text: "Place compensating controls in the form of PSP and RBAC for
+    privileged containers usage (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow Kubernetes documentation and setup PSP and RBAC authorization for your cluster.
+    scored: false

--- a/build-scripts/benchmark-conf/1.8/node.yaml
+++ b/build-scripts/benchmark-conf/1.8/node.yaml
@@ -1,0 +1,440 @@
+---
+controls:
+version: 1.8
+id: 2
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+- id: 2.1
+  text: "Kubelet"
+  checks:
+  - id: 2.1.1
+    text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--allow-privileged"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --allow-privileged=false
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.2
+    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--anonymous-auth"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --anonymous-auth=false
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.3
+    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--authorization-mode"
+        compare:
+          op: nothave
+          value: "AlwaysAllow"
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
+      --authorization-mode=Webhook
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.4
+    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--client-ca-file"
+        set: true 
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
+      --client-ca-file=<path/to/client-ca-file>
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.5
+    text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--read-only-port"
+        compare:
+          op: eq
+          value: 0
+        set: true 
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --read-only-port=0
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.6
+    text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--streaming-connection-idle-timeout"
+        compare:
+          op: noteq
+          value: 0
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --streaming-connection-idle-timeout=5m
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.7
+    text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--protect-kernel-defaults"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --protect-kernel-defaults=true
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.8
+    text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "--make-iptables-util-chains"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and remove the --make-iptables-util-chains argument from the
+      KUBELET_SYSTEM_PODS_ARGS variable.
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.9
+    text: "Ensure that the --keep-terminated-pod-volumes argument is set to false (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--keep-terminated-pod-volumes"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --keep-terminated-pod-volumes=false
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.10
+    text: "Ensure that the --hostname-override argument is not set (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--hostname-override"
+        set: false
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and remove the --hostname-override argument from the
+      KUBELET_SYSTEM_PODS_ARGS variable.
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.11
+    text: "Ensure that the --event-qps argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--event-qps"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --event-qps=0
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.12
+    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--tls-cert-file"
+        set: true
+      - flag: "--tls-private-key-file"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection on the Kubelet.
+      Then edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-
+      kubeadm.conf on each worker node and set the below parameters in
+      KUBELET_CERTIFICATE_ARGS variable.
+      --tls-cert-file=<path/to/tls-certificate-file>
+      file=<path/to/tls-key-file>
+      --tls-private-key-
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.13
+    text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--cadvisor-port"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_CADVISOR_ARGS variable.
+      --cadvisor-port=0
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.14
+    text: "Ensure that the RotateKubeletClientCertificate argument is set to true"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "RotateKubeletClientCertificate"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and remove the --feature-
+      gates=RotateKubeletClientCertificate=false argument from the
+      KUBELET_CERTIFICATE_ARGS variable.
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.15
+    text: "Ensure that the RotateKubeletServerCertificate argument is set to true"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "RotateKubeletServerCertificate"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+      --feature-gates=RotateKubeletServerCertificate=true
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+- id: 2.2
+  text: "Configuration Files"
+  checks:
+    - id: 2.2.1
+      text: "Ensure that the kubelet.conf file permissions are set to 644 or
+      more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chmod 644 $kubeletconf
+      scored: true
+
+    - id: 2.2.2
+      text: "Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: root:root
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chown root:root /etc/kubernetes/kubelet.conf
+      scored: true
+
+    - id: 2.2.3
+      text: "Ensure that the kubelet service file permissions are set to 644 or
+      more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletunitfile; then stat -c %a $kubeletunitfile; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: 644
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chmod 755 $kubeletunitfile
+      scored: true
+
+    - id: 2.2.4
+      text: "Ensure that the kubelet service file permissions are set to 644 or
+      more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletunitfile; then stat -c %U:%G $kubeletunitfile; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chown root:root $kubeletunitfile
+      scored: true
+
+    - id: 2.2.5
+      text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more
+      restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %a $proxyconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chmod 644 $proxyconf
+      scored: true
+
+    - id: 2.2.6
+      text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
+      tests:
+        test_items:
+        - flag: "root:root"
+          set: true
+      remediation: |
+          Run the below command (based on the file location on your system) on the each worker
+          node. For example,
+          chown root:root $proxyconf
+      scored: true
+
+    - id: 2.2.7
+      text: "Ensure that the certificate authorities file permissions are set to
+      644 or more restrictive (Scored)"
+      type: manual
+      remediation: |
+        Run the following command to modify the file permissions of the --client-ca-file
+        chmod 644 <filename>
+      scored: true
+
+    - id: 2.2.8
+      text: "Ensure that the client certificate authorities file ownership is set to root:root"
+      audit: "/bin/sh -c 'if test -e $ca-file; then stat -c %U:%G $ca-file; fi'"
+      type: manual
+      remediation: |
+        Run the following command to modify the ownership of the --client-ca-file .
+        chown root:root <filename>
+      scored: true

--- a/build-scripts/benchmark-conf/1.9/master.yaml
+++ b/build-scripts/benchmark-conf/1.9/master.yaml
@@ -1,0 +1,1325 @@
+---
+controls:
+version: 1.8
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+- id: 1.1
+  text: "API Server"
+  checks:
+  - id: 1.1.1
+    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--anonymous-auth"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: | 
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --anonymous-auth=false
+
+    scored: true
+
+  - id: 1.1.2
+    text: "Ensure that the --basic-auth-file argument is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--basic-auth-file"
+        set: false
+    remediation: |
+      Follow the documentation and configure alternate mechanisms for authentication. Then,
+      edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --basic-auth-file=<filename>
+      parameter.
+    scored: true
+
+  - id: 1.1.3
+    text: "Ensure that the --insecure-allow-any-token argument is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag:  "--insecure-allow-any-token"
+        set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --insecure-allow-any-token
+      parameter.
+    scored: true
+
+  - id: 1.1.4
+    text: "Ensure that the --kubelet-https argument is set to true (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests: 
+      bin_op: or
+      test_items:
+      - flag: "--kubelet-https"
+        compare:
+          op: eq
+          value: true
+        set: true
+      - flag: "--kubelet-https"
+        set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --kubelet-https parameter.
+    scored: true
+
+  - id: 1.1.5
+    text: "Ensure that the --insecure-bind-address argument is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--insecure-bind-address"
+        set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --insecure-bind-address
+      parameter.
+    scored: true
+
+  - id: 1.1.6
+    text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--insecure-port"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      apiserver.yaml on the master node and set the below parameter.
+      --insecure-port=0
+    scored: true
+
+  - id: 1.1.7
+    text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests: 
+      bin_op: or
+      test_items:
+        - flag:  "--secure-port"
+          compare:
+            op: gt
+            value: 0
+          set: true
+        - flag: "--secure-port"
+          set: false
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and either remove the --secure-port parameter or
+      set it to a different (non-zero) desired port.
+    scored: true
+
+  - id: 1.1.8
+    text: "Ensure that the --profiling argument is set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--profiling"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --profiling=false
+    scored: true
+
+  - id: 1.1.9
+    text: "Ensure that the --repair-malformed-updates argument is set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--repair-malformed-updates"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --repair-malformed-updates=false
+    scored: true
+
+  - id: 1.1.10
+    text: "Ensure that the admission control policy is not set to AlwaysAdmit (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: nothave
+          value: AlwaysAdmit 
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that does not include AlwaysAdmit.
+    scored: true
+
+  - id: 1.1.11
+    text: "Ensure that the admission control policy is set to AlwaysPullImages (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "AlwaysPullImages"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to
+      include AlwaysPullImages.
+      --admission-control=...,AlwaysPullImages,...
+    scored: true
+
+  - id: 1.1.12
+    text: "Ensure that the admission control policy is set to DenyEscalatingExec (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "DenyEscalatingExec"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes DenyEscalatingExec.
+      --admission-control=...,DenyEscalatingExec,...
+    scored: true
+
+  - id: 1.1.13
+    text: "Ensure that the admission control policy is set to SecurityContextDeny (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "SecurityContextDeny"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to
+      include SecurityContextDeny.
+      --admission-control=...,SecurityContextDeny,...
+    scored: true
+
+  - id: 1.1.14
+    text: "Ensure that the admission control policy is set to NamespaceLifecycle (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "admission-control"
+        compare:
+          op: has
+          value: "NamespaceLifecycle"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to
+      include NamespaceLifecycle.
+      --admission-control=...,NamespaceLifecycle,...
+    scored: true
+
+  - id: 1.1.15
+    text: "Ensure that the --audit-log-path argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-path"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-path parameter to a suitable
+    path and file where you would like audit logs to be written, for example:
+            --audit-log-path=/var/log/apiserver/audit.log
+    scored: true
+
+  - id: 1.1.16
+    text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-maxage"
+        compare:
+          op: gte
+          value: 30
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-maxage parameter to 30 or
+    as an appropriate number of days:
+            --audit-log-maxage=30
+    scored: true
+
+  - id: 1.1.17
+    text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-maxbackup"
+        compare:
+          op: gte
+          value: 10
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-maxbackup parameter to 10
+      or to an appropriate value.
+      --audit-log-maxbackup=10
+    scored: true
+
+  - id: 1.1.18
+    text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--audit-log-maxsize"
+        compare:
+          op: gte
+          value: 100
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --audit-log-maxsize parameter to an
+      appropriate size in MB. For example, to set it as 100 MB:
+      --audit-log-maxsize=100
+    scored: true
+
+  - id: 1.1.19
+    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--authorization-mode"
+        compare:
+          op: nothave
+          value: "AlwaysAllow"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --authorization-mode parameter to
+      values other than AlwaysAllow. One such example could be as below.
+      --authorization-mode=RBAC
+    scored: true
+
+  - id: 1.1.20
+    text: "Ensure that the --token-auth-file parameter is not set (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--token-auth-file"
+        set: false
+    remediation: |
+      Follow the documentation and configure alternate mechanisms for authentication. Then,
+      edit the API server pod specification file $apiserverpodspec
+      on the master node and remove the --token-auth-file=<filename>
+      parameter.
+    scored: true
+
+  - id: 1.1.21
+    text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--kubelet-certificate-authority"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and setup the TLS connection between the apiserver
+      and kubelets. Then, edit the API server pod specification file
+      $apiserverpodspec on the master node and set the --
+      kubelet-certificate-authority parameter to the path to the cert file for the certificate
+      authority.
+      --kubelet-certificate-authority=<ca-string>
+    scored: true
+
+  - id: 1.1.22
+    text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are
+      set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      bin_op: and
+      test_items:
+      - flag: "--kubelet-client-certificate"
+        set: true
+      - flag: "--kubelet-client-key"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and kubelets. Then, edit API server pod specification file
+      $apiserverpodspec on the master node and set the
+      kubelet client certificate and key parameters as below.
+      --kubelet-client-certificate=<path/to/client-certificate-file>
+      --kubelet-client-key=<path/to/client-key-file>
+    scored: true
+
+  - id: 1.1.23
+    text: "Ensure that the --service-account-lookup argument is set to true (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--service-account-lookup"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --service-account-lookup=true
+    scored: true
+
+  - id: 1.1.24
+    text: "Ensure that the admission control policy is set to PodSecurityPolicy (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "PodSecurityPolicy"
+        set: true
+    remediation: |
+      Follow the documentation and create Pod Security Policy objects as per your environment.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes PodSecurityPolicy :
+      --admission-control=...,PodSecurityPolicy,...
+
+      Then restart the API Server.
+    scored: true
+
+  - id: 1.1.25
+    text: "Ensure that the --service-account-key-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--service-account-key-file"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --service-account-key-file parameter
+      to the public key file for service accounts:
+      --service-account-key-file=<filename>
+    scored: true
+
+  - id: 1.1.26
+    text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as 
+      appropriate (Scored"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      bin_op: and
+      test_items:
+      - flag: "--etcd-certfile"
+        set: true
+      - flag: "--etcd-keyfile"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and etcd. Then, edit the API server pod specification file
+      $apiserverpodspec on the master node and set the etcd
+      certificate and key file parameters.
+      --etcd-certfile=<path/to/client-certificate-file>
+      --etcd-keyfile=<path/to/client-key-file>
+    scored: true
+
+  - id: 1.1.27
+    text: "Ensure that the admission control policy is set to ServiceAccount (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "ServiceAccount"
+        set: true
+    remediation: |
+      Follow the documentation and create ServiceAccount objects as per your environment.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes ServiceAccount.
+      --admission-control=...,ServiceAccount,...
+    scored: true
+
+  - id: 1.1.28
+    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set
+    as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      bin_op: and
+      test_items:
+      - flag: "--tls-cert-file"
+        set: true
+      - flag: "--tls-private-key-file"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the TLS certificate and private key file
+      parameters.
+      --tls-cert-file=<path/to/tls-certificate-file>
+      --tls-private-key-file=<path/to/tls-key-file>
+    scored: true
+
+  - id: 1.1.29
+    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--client-ca-file"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the client certificate authority file.
+      --client-ca-file=<path/to/client-ca-file>
+    scored: true
+
+  - id: 1.1.30
+    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--etcd-cafile"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and etcd. Then, edit the API server pod specification file
+      $apiserverpodspec on the master node and set the etcd
+      certificate authority file parameter.
+      --etcd-cafile=<path/to/ca-file>
+    scored: true
+
+  - id: 1.1.31
+    text: "Ensure that the --authorization-mode argument is set to Node (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--authorization-mode"
+        compare:
+          op: has
+          value: "Node"
+        set: true
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --authorization-mode parameter to a
+      value that includes Node.
+      --authorization-mode=Node,RBAC
+    scored: true
+
+  - id: 1.1.32
+    text: "Ensure that the admission control policy is set to NodeRestriction (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "NodeRestriction"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+      Then, edit the API server pod specification file $apiserverpodspec
+      on the master node and set the --admission-control parameter to a
+      value that includes NodeRestriction.
+      --admission-control=...,NodeRestriction,...
+    scored: true
+
+  - id: 1.1.33
+    text: "Ensure that the --experimental-encryption-provider-config argument is
+    set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--experimental-encryption-provider-config"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and configure a EncryptionConfig file. Then, edit
+      the API server pod specification file $apiserverpodspec
+      on the master node and set the --experimental-encryption-provider-config parameter
+      to the path of that file:
+      --experimental-encryption-provider-config=</path/to/EncryptionConfig/File>
+    scored: true
+
+  - id: 1.1.34
+    text: "Ensure that the encryption provider is set to aescbc (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and configure a EncryptionConfig file. In this file,
+      choose aescbc as the encryption provider.
+      For example,
+      kind: EncryptionConfig
+      apiVersion: v1
+      resources:
+        - resources:
+          - secrets
+            providers:
+            - aescbc:
+                keys:
+                - name: key1
+                  secret: <32-byte base64-encoded secret>
+    scored: true
+
+  - id: 1.1.35
+    text: "Ensure that the admission control policy is set to EventRateLimit (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--admission-control"
+        compare:
+          op: has
+          value: "EventRateLimit"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set the desired limits in a configuration file.
+      Then, edit the API server pod specification file $apiserverpodspec
+      and set the below parameters.
+      --admission-control=EventRateLimit
+      --admission-control-config-file=<path/to/configuration/file>
+    scored: true
+
+  - id: 1.1.36
+    text: "Ensure that the AdvancedAuditing argument is not set to false (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and set the desired audit policy in the
+      /etc/kubernetes/audit-policy.yaml file. Then, edit the API server pod specification file $apiserverpodspec
+      and set the below parameters.
+      --audit-policy-file=/etc/kubernetes/audit-policy.yaml
+    scored: true
+
+  - id: 1.1.37
+    text: "Ensure that the --request-timeout argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $apiserverbin | grep -v grep"
+    type: "manual"
+    remediation: |
+      Edit the API server pod specification file $apiserverpodspec
+      and set the below parameter as appropriate and if needed. For example,
+      --request-timeout=300
+    scored: true
+
+- id: 1.2
+  text: "Scheduler"
+  checks:
+  - id: 1.2.1
+    text: "Ensure that the --profiling argument is set to false (Scored)"
+    audit: "ps -ef | grep $schedulerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--profiling"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Remediation:
+        Edit the Scheduler pod specification file $apiserverpodspec
+        file on the master node and set the below parameter.
+        --profiling=false
+    scored: true
+
+- id: 1.3
+  text: "Controller Manager"
+  checks:
+  - id: 1.3.1
+    text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+        - flag: "--terminated-pod-gc-threshold"
+          set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold, for example:
+      --terminated-pod-gc-threshold=10
+    scored: true
+
+  - id: 1.3.2
+    text: "Ensure that the --profiling argument is set to false (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--profiling"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the below parameter.
+      --profiling=false
+    scored: true
+
+  - id: 1.3.3
+    text: "Ensure that the --use-service-account-credentials argument is set"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--use-service-account-credentials"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node to set the below parameter.
+      --use-service-account-credentials=true
+    scored: true
+
+  - id: 1.3.4
+    text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--service-account-private-key-file"
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the --service-account-private-
+      key-file parameter to the private key file for service accounts.
+      --service-account-private-key-file=<filename>
+    scored: true
+
+  - id: 1.3.5
+    text: "Ensure that the --root-ca-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--root-ca-file"
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      on the master node and set the --root-ca-file parameter to
+      the certificate bundle file.
+      --root-ca-file=<path/to/file>
+    scored: true
+
+  - id: 1.3.6
+    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and apply security contexts to your pods. For a
+      suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+      Containers.
+    scored: false
+
+  - id: 1.3.7
+    text: " Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
+    audit: "ps -ef | grep $controllermanagerbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "RotateKubeletServerCertificate"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the Controller Manager pod specification file $apiserverpodspec
+      controller-manager.yaml on the master node and set the --feature-gates parameter to
+      include RotateKubeletServerCertificate=true.
+      --feature-gates=RotateKubeletServerCertificate=true
+    scored: true
+
+- id: 1.4
+  text: "Configuration Files"
+  checks:
+  - id: 1.4.1
+    text: "Ensure that the API server pod specification file permissions are
+    set to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $apiserverpodspec; then stat -c %a $apiserverpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $apiserverpodspec
+    scored: true
+
+  - id: 1.4.2
+    text: "Ensure that the API server pod specification file ownership is set to
+    root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $apiserverpodspec; then stat -c %U:%G $apiserverpodspec; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $apiserverpodspec
+    scored: true
+
+  - id: 1.4.3
+    text: "Ensure that the controller manager pod specification file
+    permissions are set to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerpodspec; then stat -c %a $controllermanagerpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+      - flag: "640"
+        compare:
+          op: eq
+          value: "640"
+        set: true
+      - flag: "600"
+        compare:
+          op: eq
+          value: "600"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $controllermanagerpodspec
+    scored: true
+
+  - id: 1.4.4
+    text: "Ensure that the controller manager pod specification file
+    ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerpodspec; then stat -c %U:%G $controllermanagerpodspec; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $controllermanagerpodspec
+    scored: true
+
+  - id: 1.4.5
+    text: "Ensure that the scheduler pod specification file permissions are set
+    to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerpodspec; then stat -c %a $schedulerpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $schedulerpodspec
+    scored: true
+
+  - id: 1.4.6
+    text: "Ensure that the scheduler pod specification file ownership is set to
+    root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerpodspec; then stat -c %U:%G $schedulerpodspec; fi'"
+    tests:
+      test_items:
+        - flag: "root:root"
+          compare:
+            op: eq
+            value: "root:root"
+          set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $schedulerpodspec
+    scored: true
+
+  - id: 1.4.7
+    text: "Ensure that the etcd pod specification file permissions are set to
+    644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $etcdpodspec; then stat -c %a $etcdpodspec; fi'"
+    tests:
+      bin_op: or
+      test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $etcdpodspec
+    scored: true
+
+  - id: 1.4.8
+    text: "Ensure that the etcd pod specification file ownership is set to
+    root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $etcdpodspec; then stat -c %U:%G $etcdpodspec; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $etcdpodspec
+    scored: true
+
+  - id: 1.4.9
+    text: "Ensure that the Container Network Interface file permissions are
+    set to 644 or more restrictive (Not Scored)"
+    audit: "stat -c %a <path/to/cni/files>"
+    type: manual
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 <path/to/cni/files>
+    scored: true
+
+  - id: 1.4.10
+    text: "Ensure that the Container Network Interface file ownership is set
+    to root:root (Not Scored)"
+    audit: "stat -c %U:%G <path/to/cni/files>"
+    type: manual
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root <path/to/cni/files>
+    scored: true
+
+  - id: 1.4.11
+    text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %a"
+    tests:
+      test_items:
+      - flag: "700"
+        compare:
+          op: eq
+          value: "700"
+        set: true
+    remediation: |
+      On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+      from the below command:
+      ps -ef | grep $etcdbin
+      Run the below command (based on the etcd data directory found above). For example,
+      chmod 700 /var/lib/etcd
+    scored: true
+
+  - id: 1.4.12
+    text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs stat -c %U:%G"
+    tests:
+      test_items:
+      - flag: "etcd:etcd"
+        set: true
+    remediation: |
+      On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
+      from the below command:
+      ps -ef | grep $etcdbin
+      Run the below command (based on the etcd data directory found above). For example,
+      chown etcd:etcd /var/lib/etcd
+    scored: true
+
+  - id: 1.4.13
+    text: "Ensure that the admin.conf file permissions are set to 644 or
+    more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %a /etc/kubernetes/admin.conf; fi'"
+    tests:
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 /etc/kubernetes/admin.conf
+    scored: true
+
+  - id: 1.4.14
+    text: "Ensure that the admin.conf file ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root /etc/kubernetes/admin.conf
+    scored: true
+
+  - id: 1.4.15
+    text: "Ensure that the scheduler.conf file permissions are set to 644 or
+    more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerconf then stat -c %a $schedulerconf; fi'"
+    tests:
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $schedulerconf
+    scored: true
+
+  - id: 1.4.16
+    text: "Ensure that the scheduler.conf file ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $schedulerconf
+    scored: true
+
+  - id: 1.4.17
+    text: "Ensure that the controller-manager.conf file permissions are set
+    to 644 or more restrictive (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerconf then stat -c %a $controllermanagerconf; fi'"
+    tests:
+      test_items:
+      - flag: "644"
+        compare:
+          op: eq
+          value: "644"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chmod 644 $controllermanagerconf
+    scored: true
+
+  - id: 1.4.18
+    text: "Ensure that the controller-manager.conf file ownership is set to root:root (Scored)"
+    audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+    tests:
+      test_items:
+      - flag: "root:root"
+        compare:
+          op: eq
+          value: "root:root"
+        set: true
+    remediation: |
+      Run the below command (based on the file location on your system) on the master node.
+      For example,
+      chown root:root $controllermanagerconf
+    scored: true
+
+- id: 1.5
+  text: "etcd"
+  checks:
+  - id: 1.5.1
+    text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--cert-file"
+        set: true
+      - flag:  "--key-file"
+        set: true
+    remediation: |
+      Follow the etcd service documentation and configure TLS encryption.
+      Then, edit the etcd pod specification file $etcdpodspec on the
+      master node and set the below parameters.
+      --ca-file=</path/to/ca-file>
+      --key-file=</path/to/key-file>
+    scored: true
+
+  - id: 1.5.2
+    text: "Ensure that the --client-cert-auth argument is set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--client-cert-auth"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --client-cert-auth="true"
+    scored: true
+
+  - id: 1.5.3
+    text: "Ensure that the --auto-tls argument is not set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "--auto-tls"
+        set: false
+      - flag: "--auto-tls"
+        compare:
+          op: neq
+          value: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and either remove the --auto-tls parameter or set it to false.
+        --auto-tls=false
+    scored: true
+
+  - id: 1.5.4
+    text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set
+    as appropriate (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--peer-cert-file"
+        set: true
+      - flag: "--peer-key-file"
+        set: true
+    remediation: |
+      Follow the etcd service documentation and configure peer TLS encryption as appropriate
+      for your etcd cluster. Then, edit the etcd pod specification file $etcdpodspec on the
+      master node and set the below parameters.
+      --peer-client-file=</path/to/peer-cert-file>
+      --peer-key-file=</path/to/peer-key-file>
+    scored: true
+
+  - id: 1.5.5
+    text: "Ensure that the --peer-client-cert-auth argument is set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--peer-client-cert-auth"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --peer-client-cert-auth=true
+    scored: true
+
+  - id: 1.5.6
+    text: "Ensure that the --peer-auto-tls argument is not set to true (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "--peer-auto-tls"
+        set: false
+      - flag: "--peer-auto-tls"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and either remove the --peer-auto-tls parameter or set it to false.
+      --peer-auto-tls=false
+    scored: true
+
+  - id: 1.5.7
+    text: "Ensure that the --wal-dir argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--wal-dir"
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --wal-dir=</path/to/log/dir>
+    scored: true
+
+  - id: 1.5.8
+    text: "Ensure that the --max-wals argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--max-wals"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the etcd pod specification file $etcdpodspec on the master
+      node and set the below parameter.
+      --max-wals=0
+    scored: true
+
+  - id: 1.5.9
+    text: "Ensure that a unique Certificate Authority is used for etcd (Not Scored)"
+    audit: "ps -ef | grep $etcdbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--trusted-ca-file"
+        set: true
+    remediation: |
+      Follow the etcd documentation and create a dedicated certificate authority setup for the
+      etcd service.
+      Then, edit the etcd pod specification file $etcdpodspec on the
+      master node and set the below parameter.
+      --trusted-ca-file=</path/to/ca-file>
+    scored: false 
+
+- id: 1.6
+  text: "General Security Primitives"
+  checks:
+  - id: 1.6.1
+    text: "Ensure that the cluster-admin role is only used where required (Not Scored)"
+    type: "manual"
+    remediation: |
+      Remove any unneeded clusterrolebindings :
+      kubectl delete clusterrolebinding [name]
+    scored: false
+
+  - id: 1.6.2
+    text: "Create Pod Security Policies for your cluster (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the documentation and create and enforce Pod Security Policies for your cluster.
+      Additionally, you could refer the "CIS Security Benchmark for Docker" and follow the
+      suggested Pod Security Policies for your environment.
+    scored: false
+
+  - id: 1.6.3
+    text: "Create administrative boundaries between resources using namespaces (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the documentation and create namespaces for objects in your deployment as you
+      need them.
+    scored: false
+
+  - id: 1.6.4
+    text: "Create network segmentation using Network Policies (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the documentation and create NetworkPolicy objects as you need them.
+    scored: false
+
+  - id: 1.6.5
+    text: "Ensure that the seccomp profile is set to docker/default in your pod 
+    definitions (Not Scored)"
+    type: "manual"
+    remediation: |
+      Seccomp is an alpha feature currently. By default, all alpha features are disabled. So, you
+      would need to enable alpha features in the apiserver by passing "--feature-
+      gates=AllAlpha=true" argument.
+      Edit the $apiserverconf file on the master node and set the KUBE_API_ARGS
+      parameter to "--feature-gates=AllAlpha=true"
+      KUBE_API_ARGS="--feature-gates=AllAlpha=true"
+      Based on your system, restart the kube-apiserver service. For example:
+      systemctl restart kube-apiserver.service
+      Use annotations to enable the docker/default seccomp profile in your pod definitions. An
+      example is as below:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: trustworthy-pod
+        annotations:
+          seccomp.security.alpha.kubernetes.io/pod: docker/default
+      spec:
+        containers:
+          - name: trustworthy-container
+            image: sotrustworthy:latest
+    scored: false
+
+  - id: 1.6.6
+    text: "Apply Security Context to Your Pods and Containers (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and apply security contexts to your pods. For a
+      suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+      Containers.
+    scored: false
+
+  - id: 1.6.7
+    text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and setup image provenance.
+    scored: false
+
+  - id: 1.6.8
+    text: "Configure Network policies as appropriate (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow the Kubernetes documentation and setup network policies as appropriate.
+      For example, you could create a "default" isolation policy for a Namespace by creating a
+      NetworkPolicy that selects all pods but does not allow any traffic:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: default-deny
+      spec:
+        podSelector:
+    scored: false
+
+  - id: 1.6.9
+    text: "Place compensating controls in the form of PSP and RBAC for
+    privileged containers usage (Not Scored)"
+    type: "manual"
+    remediation: |
+      Follow Kubernetes documentation and setup PSP and RBAC authorization for your cluster.
+    scored: false

--- a/build-scripts/benchmark-conf/1.9/node.yaml
+++ b/build-scripts/benchmark-conf/1.9/node.yaml
@@ -1,0 +1,440 @@
+---
+controls:
+version: 1.8
+id: 2
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+- id: 2.1
+  text: "Kubelet"
+  checks:
+  - id: 2.1.1
+    text: "Ensure that the --allow-privileged argument is set to false (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--allow-privileged"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --allow-privileged=false
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.2
+    text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--anonymous-auth"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --anonymous-auth=false
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.3
+    text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--authorization-mode"
+        compare:
+          op: nothave
+          value: "AlwaysAllow"
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
+      --authorization-mode=Webhook
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.4
+    text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--client-ca-file"
+        set: true 
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_AUTHZ_ARGS variable.
+      --client-ca-file=<path/to/client-ca-file>
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.5
+    text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--read-only-port"
+        compare:
+          op: eq
+          value: 0
+        set: true 
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --read-only-port=0
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.6
+    text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--streaming-connection-idle-timeout"
+        compare:
+          op: noteq
+          value: 0
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --streaming-connection-idle-timeout=5m
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.7
+    text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--protect-kernel-defaults"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --protect-kernel-defaults=true
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.8
+    text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      bin_op: or
+      test_items:
+      - flag: "--make-iptables-util-chains"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and remove the --make-iptables-util-chains argument from the
+      KUBELET_SYSTEM_PODS_ARGS variable.
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.9
+    text: "Ensure that the --keep-terminated-pod-volumes argument is set to false (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--keep-terminated-pod-volumes"
+        compare:
+          op: eq
+          value: false
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --keep-terminated-pod-volumes=false
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.10
+    text: "Ensure that the --hostname-override argument is not set (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--hostname-override"
+        set: false
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and remove the --hostname-override argument from the
+      KUBELET_SYSTEM_PODS_ARGS variable.
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.11
+    text: "Ensure that the --event-qps argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--event-qps"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+      --event-qps=0
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.12
+    text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--tls-cert-file"
+        set: true
+      - flag: "--tls-private-key-file"
+        set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection on the Kubelet.
+      Then edit the kubelet service file /etc/systemd/system/kubelet.service.d/10-
+      kubeadm.conf on each worker node and set the below parameters in
+      KUBELET_CERTIFICATE_ARGS variable.
+      --tls-cert-file=<path/to/tls-certificate-file>
+      file=<path/to/tls-key-file>
+      --tls-private-key-
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.13
+    text: "Ensure that the --cadvisor-port argument is set to 0 (Scored)"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "--cadvisor-port"
+        compare:
+          op: eq
+          value: 0
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_CADVISOR_ARGS variable.
+      --cadvisor-port=0
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.14
+    text: "Ensure that the RotateKubeletClientCertificate argument is set to true"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "RotateKubeletClientCertificate"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and remove the --feature-
+      gates=RotateKubeletClientCertificate=false argument from the
+      KUBELET_CERTIFICATE_ARGS variable.
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+  - id: 2.1.15
+    text: "Ensure that the RotateKubeletServerCertificate argument is set to true"
+    audit: "ps -ef | grep $kubeletbin | grep -v grep"
+    tests:
+      test_items:
+      - flag: "RotateKubeletServerCertificate"
+        compare:
+          op: eq
+          value: true
+        set: true
+    remediation: |
+      Edit the kubelet service file $kubeletunitfile
+      on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+      --feature-gates=RotateKubeletServerCertificate=true
+      Based on your system, restart the kubelet service. For example:
+      systemctl daemon-reload
+      systemctl restart kubelet.service
+    scored: true
+
+- id: 2.2
+  text: "Configuration Files"
+  checks:
+    - id: 2.2.1
+      text: "Ensure that the kubelet.conf file permissions are set to 644 or
+      more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %a $kubeletconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+          - flag: "640"
+            compare:
+              op: eq
+              value: "640"
+            set: true
+          - flag: "600"
+            compare:
+              op: eq
+              value: "600"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chmod 644 $kubeletconf
+      scored: true
+
+    - id: 2.2.2
+      text: "Ensure that the kubelet.conf file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: root:root
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chown root:root /etc/kubernetes/kubelet.conf
+      scored: true
+
+    - id: 2.2.3
+      text: "Ensure that the kubelet service file permissions are set to 644 or
+      more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletunitfile; then stat -c %a $kubeletunitfile; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: 644
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chmod 755 $kubeletunitfile
+      scored: true
+
+    - id: 2.2.4
+      text: "Ensure that the kubelet service file permissions are set to 644 or
+      more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $kubeletunitfile; then stat -c %U:%G $kubeletunitfile; fi'"
+      tests:
+        test_items:
+        - flag: "root:root"
+          set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chown root:root $kubeletunitfile
+      scored: true
+
+    - id: 2.2.5
+      text: "Ensure that the proxy kubeconfig file permissions are set to 644 or more
+      restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $proxyconf; then stat -c %a $proxyconf; fi'"
+      tests:
+        bin_op: or
+        test_items:
+        - flag: "644"
+          compare:
+            op: eq
+            value: "644"
+          set: true
+        - flag: "640"
+          compare:
+            op: eq
+            value: "640"
+          set: true
+        - flag: "600"
+          compare:
+            op: eq
+            value: "600"
+          set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the each worker
+        node. For example,
+        chmod 644 $proxyconf
+      scored: true
+
+    - id: 2.2.6
+      text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Scored)"
+      tests:
+        test_items:
+        - flag: "root:root"
+          set: true
+      remediation: |
+          Run the below command (based on the file location on your system) on the each worker
+          node. For example,
+          chown root:root $proxyconf
+      scored: true
+
+    - id: 2.2.7
+      text: "Ensure that the certificate authorities file permissions are set to
+      644 or more restrictive (Scored)"
+      type: manual
+      remediation: |
+        Run the following command to modify the file permissions of the --client-ca-file
+        chmod 644 <filename>
+      scored: true
+
+    - id: 2.2.8
+      text: "Ensure that the client certificate authorities file ownership is set to root:root"
+      audit: "/bin/sh -c 'if test -e $ca-file; then stat -c %U:%G $ca-file; fi'"
+      type: manual
+      remediation: |
+        Run the following command to modify the ownership of the --client-ca-file .
+        chown root:root <filename>
+      scored: true

--- a/build-scripts/benchmark-conf/config.yaml
+++ b/build-scripts/benchmark-conf/config.yaml
@@ -1,0 +1,73 @@
+---
+## Controls Files. 
+# These are YAML files that hold all the details for running checks.
+#
+## Uncomment to use different control file paths.
+# masterControls: ./cfg/master.yaml
+# nodeControls: ./cfg/node.yaml
+# federatedControls: ./cfg/federated.yaml
+
+master:
+  components:
+    - apiserver
+    - scheduler
+    - controllermanager
+    # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
+    - kubernetes
+
+  kubernetes:
+    defaultconf: /etc/kubernetes/config
+
+  apiserver:
+    bins:
+      - "hyperkube apiserver"
+    defaultpodspec: /etc/kubernetes/manifests/kube-apiserver.yaml
+
+  scheduler:
+    bins:
+      - "hyperkube scheduler"
+    defaultpodspec: /etc/kubernetes/manifests/scheduler.yaml
+
+  controllermanager:
+    bins:
+      - "hyperkube controller-manager"
+    defaultpodspec: /etc/kubernetes/manifests/controller-manager.yaml
+
+  etcd:
+    optional: true
+    bins:
+      - "etcd"
+    confs:
+      - /etc/etcd/etcd.conf
+    defaultconf: /etc/etcd/etcd.conf
+
+    podspecs:
+      - /etc/kubernetes/manifests/etcd.yaml
+    defaultpodspec: /etc/kubernetes/manifests/etcd.yaml
+
+  flanneld:
+    optional: true
+    bins:
+      - flanneld
+    defaultconf: /etc/sysconfig/flanneld
+
+
+node:
+  components:
+    - kubelet
+    - proxy
+    # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
+    - kubernetes
+
+  kubernetes:
+    defaultconf: /etc/kubernetes/config    
+
+  kubelet:
+    bins:
+      - "hyperkube kubelet"
+    defaultunitfile: /etc/systemd/system/kubelet.service
+  
+  proxy:
+    bins:
+      - "hyperkube proxy"
+    defaultpodspec: /etc/kubernetes/manifests/kube-proxy.yaml

--- a/build-scripts/benchmark-tests
+++ b/build-scripts/benchmark-tests
@@ -73,7 +73,8 @@ main() {
   echo "Summary of tests for cluster: ${cluster_pass_checks}/${cluster_total_checks} passed checks" > ${CLUSTER_TEST_RESULTS}/cluster-results.txt
   cat ${CLUSTER_TEST_RESULTS}/cluster-results.txt
 
-  exit 0
+  # return success only if all checks passed
+  exit $(expr ${cluster_total_checks} - ${cluster_pass_checks})
 }
 
 main "$@"

--- a/build-scripts/benchmark-tests
+++ b/build-scripts/benchmark-tests
@@ -12,15 +12,32 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REMOTE_BENCHMARK_DIR=/home/core/benchmark-test
-REMOTE_BENCHMARK_CONF=${REMOTE_BENCHMARK_DIR}/kraken-conf
-SSH_CONFIG=~/.kraken/${CLUSTER}/ssh_config
+CLUSTER_CONF_DIR=${1:?The cluster configuration directory is required}
+CLUSTER_CONF=${CLUSTER_CONF_DIR}/${2:-config.yaml}
 CLUSTER_TEST_RESULTS=./build/tests
 
+REMOTE_BENCHMARK_DIR=/home/core/benchmark-test
+REMOTE_BENCHMARK_CONF=${REMOTE_BENCHMARK_DIR}/kraken-conf
+
+# This function gets the name of the cluster from the kraken config file.
+get_cluster_name() {
+  local conf_file=$1
+  local cluster_name=$(grep '^[[:space:]]\{4\}- name' ${conf_file} | awk '{print $3}')
+  echo ${cluster_name}
+}
+
+# This function gets the names of the nodes execpt etcd nodes from the ssh_config file
+get_node_names() {
+  local ssh_config=$1
+  grep -o "Host .*" "${ssh_config}" | grep -v etcd | awk '{print $2}' | tr '\n' ' '
+}
+
 main() {
-  # this gets the provisioned kraken nodes except the etcd nodes
+  local cluster_name=$(get_cluster_name ${CLUSTER_CONF})
+  local cluster_ssh_config=${CLUSTER_CONF_DIR}/${cluster_name}/ssh_config
+
   declare -a cluster_nodes
-  cluster_nodes=$(grep -o "Host .*" ${SSH_CONFIG} | grep -v etcd | awk '{print $2}' | tr '\n' ' ')
+  cluster_nodes=$(get_node_names ${cluster_ssh_config})
   
   local cluster_pass_checks=0
   local cluster_total_checks=0
@@ -28,19 +45,19 @@ main() {
   
   for node in ${cluster_nodes[@]}; do
     printf "\nSetting up node (%s)\n" "${node}"
-    ssh -qF ${SSH_CONFIG} ${node} "mkdir -p ${REMOTE_BENCHMARK_DIR}"
+    ssh -qF ${cluster_ssh_config} ${node} "mkdir -p ${REMOTE_BENCHMARK_DIR}"
   
     printf "Sending test script to node\n"
-    scp -qF ${SSH_CONFIG} ./hack/benchmark-test.sh ${node}:${REMOTE_BENCHMARK_DIR}
+    scp -qF ${cluster_ssh_config} ./hack/benchmark-test.sh ${node}:${REMOTE_BENCHMARK_DIR}
 
     printf "Sending configs to node\n"
-    scp -rpqF ${SSH_CONFIG} ./build-scripts/benchmark-conf ${node}:${REMOTE_BENCHMARK_CONF}
+    scp -rpqF ${cluster_ssh_config} ./build-scripts/benchmark-conf ${node}:${REMOTE_BENCHMARK_CONF}
 
     printf "Executing test on node\n"
-    ssh -qF ${SSH_CONFIG} core@${node} "cd ${REMOTE_BENCHMARK_DIR}; ./benchmark-test.sh ${node}"
+    ssh -qF ${cluster_ssh_config} core@${node} "cd ${REMOTE_BENCHMARK_DIR}; ./benchmark-test.sh ${node}"
 
     printf "Getting test results from node\n"
-    scp -qF ${SSH_CONFIG} ${node}:${REMOTE_BENCHMARK_DIR}/*results* ${CLUSTER_TEST_RESULTS}
+    scp -qF ${cluster_ssh_config} ${node}:${REMOTE_BENCHMARK_DIR}/*results* ${CLUSTER_TEST_RESULTS}
 
     local pass_checks=$(grep -o "[0-9]\+ checks PASS" ${CLUSTER_TEST_RESULTS}/*${node}-results.txt | awk '{print $1}')
     local fail_checks=$(grep -o "[0-9]\+ checks FAIL" ${CLUSTER_TEST_RESULTS}/*${node}-results.txt | awk '{print $1}')
@@ -50,10 +67,11 @@ main() {
     printf "Summary of test for node (%s): %d/%d passed checks\n" "${node}" "${pass_checks}" "${total_checks}"
 
     printf "Cleaning up node\n"
-    ssh -qF ${SSH_CONFIG} ${node} "rm -rf ${REMOTE_BENCHMARK_DIR}"
+    ssh -qF ${cluster_ssh_config} ${node} "rm -rf ${REMOTE_BENCHMARK_DIR}"
   done
 
-  printf "\nSummary of tests for cluster (%s): %d/%d passed checks\n" "${CLUSTER}" "${cluster_pass_checks}" "${cluster_total_checks}"
+  echo "Summary of tests for cluster: ${cluster_pass_checks}/${cluster_total_checks} passed checks" > ${CLUSTER_TEST_RESULTS}/cluster-results.txt
+  cat ${CLUSTER_TEST_RESULTS}/cluster-results.txt
 
   exit 0
 }

--- a/build-scripts/benchmark-tests
+++ b/build-scripts/benchmark-tests
@@ -22,8 +22,7 @@ REMOTE_BENCHMARK_CONF=${REMOTE_BENCHMARK_DIR}/kraken-conf
 # This function gets the name of the cluster from the kraken config file.
 get_cluster_name() {
   local conf_file=$1
-  local cluster_name=$(grep '^[[:space:]]\{4\}- name' ${conf_file} | awk '{print $3}')
-  echo ${cluster_name}
+  grep '^[[:space:]]\{4\}- name' ${conf_file} | awk '{print $3}'
 }
 
 # This function gets the names of the nodes execpt etcd nodes from the ssh_config file

--- a/build-scripts/benchmark-tests
+++ b/build-scripts/benchmark-tests
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# This script is the main controlling test script to run
+# the kubernetes benchmark tests w/kube-bench. This script
+# assumes you are executing inside a kraken-tools container
+#
+# In regards to reporting this script just reports:
+#   - pass/total checks for each node
+#   - cluster summary which simply sums node results
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REMOTE_BENCHMARK_DIR=/home/core/benchmark-test
+REMOTE_BENCHMARK_CONF=${REMOTE_BENCHMARK_DIR}/kraken-conf
+SSH_CONFIG=~/.kraken/${CLUSTER}/ssh_config
+CLUSTER_TEST_RESULTS=./build/tests
+
+main() {
+  # this gets the provisioned kraken nodes except the etcd nodes
+  declare -a cluster_nodes
+  cluster_nodes=$(grep -o "Host .*" ${SSH_CONFIG} | grep -v etcd | awk '{print $2}' | tr '\n' ' ')
+  
+  local cluster_pass_checks=0
+  local cluster_total_checks=0
+  mkdir -p ${CLUSTER_TEST_RESULTS}
+  
+  for node in ${cluster_nodes[@]}; do
+    printf "\nSetting up node (%s)\n" "${node}"
+    ssh -qF ${SSH_CONFIG} ${node} "mkdir -p ${REMOTE_BENCHMARK_DIR}"
+  
+    printf "Sending test script to node\n"
+    scp -qF ${SSH_CONFIG} ./hack/benchmark-test.sh ${node}:${REMOTE_BENCHMARK_DIR}
+
+    printf "Sending configs to node\n"
+    scp -rpqF ${SSH_CONFIG} ./build-scripts/benchmark-conf ${node}:${REMOTE_BENCHMARK_CONF}
+
+    printf "Executing test on node\n"
+    ssh -qF ${SSH_CONFIG} core@${node} "cd ${REMOTE_BENCHMARK_DIR}; ./benchmark-test.sh ${node}"
+
+    printf "Getting test results from node\n"
+    scp -qF ${SSH_CONFIG} ${node}:${REMOTE_BENCHMARK_DIR}/*results* ${CLUSTER_TEST_RESULTS}
+
+    local pass_checks=$(grep -o "[0-9]\+ checks PASS" ${CLUSTER_TEST_RESULTS}/*${node}-results.txt | awk '{print $1}')
+    local fail_checks=$(grep -o "[0-9]\+ checks FAIL" ${CLUSTER_TEST_RESULTS}/*${node}-results.txt | awk '{print $1}')
+    local total_checks=$(expr ${pass_checks} + ${fail_checks})
+    cluster_pass_checks=$(expr ${pass_checks} + ${cluster_pass_checks})
+    cluster_total_checks=$(expr ${total_checks} + ${cluster_total_checks})
+    printf "Summary of test for node (%s): %d/%d passed checks\n" "${node}" "${pass_checks}" "${total_checks}"
+
+    printf "Cleaning up node\n"
+    ssh -qF ${SSH_CONFIG} ${node} "rm -rf ${REMOTE_BENCHMARK_DIR}"
+  done
+
+  printf "\nSummary of tests for cluster (%s): %d/%d passed checks\n" "${CLUSTER}" "${cluster_pass_checks}" "${cluster_total_checks}"
+
+  exit 0
+}
+
+main "$@"

--- a/hack/benchmark-test.sh
+++ b/hack/benchmark-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# This script gets and executes kube-bench on a cluster node.
+# 
+# References:
+#   [1]: https://github.com/aquasecurity/kube-bench#installation
+#
+# Example: ./benchmark-test.sh master-1
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# setup kube-bench params
+NODE_NAME=${1:?NODE_NAME must be set}
+if [[ $NODE_NAME == master* ]]; then
+  NODE_TYPE=master
+else
+  NODE_TYPE=node
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+KUBE_BENCHMARK_RESULTS=${SCRIPT_DIR}/kube-bench-${NODE_NAME}-results.txt
+KRAKEN_BENCHMARK_CONF=${SCRIPT_DIR}/kraken-conf
+PATH=$PATH:${SCRIPT_DIR}
+
+printf "Getting kubectl\n"
+K8S_VERSION=v1.9.0
+K8S_SHA256=9150691c3c9d0c3d6c0c570a81221f476e107994b35e33c193b1b90b7b7c0cb5
+KUBECTL_URL=https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl 
+
+wget -q ${KUBECTL_URL}
+echo "${K8S_SHA256}  kubectl" | sha256sum -c -
+chmod a+x kubectl
+
+printf "Checking K8S version\n"
+export KUBECONFIG=/etc/kubernetes/kubeconfig.yaml
+kubectl --kubeconfig ${KUBECONFIG} version --short
+
+printf "Getting kube-bench\n" #[1]
+docker run --rm -v $(pwd):/host aquasec/kube-bench:latest
+sudo chown core:core kube-bench
+sudo rm -rf ./cfg
+cp -r ${KRAKEN_BENCHMARK_CONF} cfg/
+
+printf "Executing kube-bench\n"
+kube-bench ${NODE_TYPE} > ${KUBE_BENCHMARK_RESULTS}


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds a CI job that runs the [kube-bench][2] tool on a Kraken cluster. The kube-bench tool is an implementation of the [CIS Benchmark for Kubernetes][1]. This will allow us to establish a baseline metric in regards to the security posture of a Kraken provisioned cluster.

**Which issue this PR fixes**: fixes #660 ([BAC-102][102])

**How to Verify**
- This PR should invoke the new `test-security:benchmark` (and `benchmark-minus-one` and `benchmark-minus-two`) in the gitlab pipeline. On success of this job the test result artifacts should be associated with the gitlab job. You should be able to verify these files manually.
- Additionally this can be invoked locally with the following command:
```
docker run \
  -v ~/.ssh:/root/.ssh \
  -v ~/.ssh:$(dirname ~/.ssh)/.ssh \
  -v ~/.kraken:/root/.kraken \
  -v $(PWD):/root/kraken-lib \
  -w /root/kraken-lib \
  quay.io/samsung_cnct/kraken-tools:latest  ./build-scripts/benchmark-tests "/root/.kraken"
  ```
By default this will try and run the bench mark on the cluster specified in `~/.kraken/config.yaml`

**Notes**:
- This issue does not address wether or not the recommended remediation of failed checks are valid for a Kraken cluster. A separate issue should be created to address this.
- A report for each node in the cluster will generated to `./builds/tests/`

[1]: https://www.cisecurity.org/benchmark/kubernetes/
[2]: https://github.com/aquasecurity/kube-bench
[102]: https://samsung-cnct.atlassian.net/browse/BAC-102