### PR TITLE
add system log mount to master kubelets

### DIFF
--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -31,6 +31,7 @@
       --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
       --mount volume=var-lib-docker,target=/var/lib/docker \
       --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+      --mount volume=var-log,target=/var/log \
       --mount volume=os-release,target=/etc/os-release \
       --mount volume=run,target=/run \
       --mount volume=opt-cni,target=/opt/cni \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -20,6 +20,7 @@
       --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
       --volume var-lib-docker,kind=host,source=/var/lib/docker \
       --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
+      --volume var-log,kind=host,source=/var/log \
       --volume os-release,kind=host,source=/usr/lib/os-release \
       --volume run,kind=host,source=/run \
       --volume opt-cni,kind=host,source=/opt/cni \
@@ -47,7 +48,6 @@
       --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem \
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --network-plugin=cni \
-      --cni-bin-dir=/etc/cni/net.d \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
       --cloud-provider={{ cluster.providerConfig.provider }} \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/units.kubelet.part.jinja2
@@ -9,6 +9,7 @@
     [Service]
     EnvironmentFile=/etc/network-environment
     ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+    ExecStartPre=/usr/bin/mkdir -p /var/log/containers
     ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
     ExecStartPre=/usr/bin/bash -c '/usr/bin/wget https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz -O - | sudo tar -xz -C /opt/cni/bin'
     ExecStartPre=/usr/bin/mkdir -p /etc/cni/net.d

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
@@ -31,6 +31,7 @@
       --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
       --mount volume=var-lib-docker,target=/var/lib/docker \
       --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+      --mount volume=var-log,target=/var/log \
       --mount volume=os-release,target=/etc/os-release \
       --mount volume=run,target=/run \
       --mount volume=opt-cni,target=/opt/cni \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
@@ -20,6 +20,7 @@
       --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
       --volume var-lib-docker,kind=host,source=/var/lib/docker \
       --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
+      --volume var-log,kind=host,source=/var/log \
       --volume os-release,kind=host,source=/usr/lib/os-release \
       --volume run,kind=host,source=/run \
       --volume opt-cni,kind=host,source=/opt/cni \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.6/units.kubelet.part.jinja2
@@ -9,6 +9,7 @@
     [Service]
     EnvironmentFile=/etc/network-environment
     ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+    ExecStartPre=/usr/bin/mkdir -p /var/log/containers
     ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
     ExecStartPre=/usr/bin/bash -c '/usr/bin/wget https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz -O - | sudo tar -xz -C /opt/cni/bin'
     ExecStartPre=/usr/bin/mkdir -p /etc/cni/net.d

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/units.kubelet.part.jinja2
@@ -31,6 +31,7 @@
       --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
       --mount volume=var-lib-docker,target=/var/lib/docker \
       --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+      --mount volume=var-log,target=/var/log \
       --mount volume=os-release,target=/etc/os-release \
       --mount volume=run,target=/run \
       --mount volume=opt-cni,target=/opt/cni \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/units.kubelet.part.jinja2
@@ -20,6 +20,7 @@
       --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
       --volume var-lib-docker,kind=host,source=/var/lib/docker \
       --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
+      --volume var-log,kind=host,source=/var/log \
       --volume os-release,kind=host,source=/usr/lib/os-release \
       --volume run,kind=host,source=/run \
       --volume opt-cni,kind=host,source=/opt/cni \

--- a/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/units.kubelet.part.jinja2
+++ b/ansible/roles/kraken.nodePool/kraken.nodePool.master/templates/v1.7/units.kubelet.part.jinja2
@@ -9,6 +9,7 @@
     [Service]
     EnvironmentFile=/etc/network-environment
     ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+    ExecStartPre=/usr/bin/mkdir -p /var/log/containers
     ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
     ExecStartPre=/usr/bin/bash -c '/usr/bin/wget https://github.com/containernetworking/cni/releases/download/v0.3.0/cni-v0.3.0.tgz -O - | sudo tar -xz -C /opt/cni/bin'
     ExecStartPre=/usr/bin/mkdir -p /etc/cni/net.d


### PR DESCRIPTION
the kubelet is responsible for making symlinks from where docker stores
log files (/var/lib/docker/) to where kubernetes says the log file
will be available (/var/lib/pods or /var/lib/containers).  to let
kubelet make these changes on the host, we need to mount the hosts
/var/log or we're just farting around in the kubelet's running
imagefs